### PR TITLE
Fix mismatched delete for array allocation

### DIFF
--- a/src/emulator.cpp
+++ b/src/emulator.cpp
@@ -320,7 +320,7 @@ void emulator_show_memdump_window(bool &show_memmap_window) {
     ImGui::EndChild();
     ImGui::End();
 
-    delete memory_dump_buffer;
+    delete[] memory_dump_buffer;
 
 }
 


### PR DESCRIPTION
## Summary
- Fix undefined behavior in `emulator.cpp:323`: `new char[]` was freed with `delete` instead of `delete[]`
- Eliminates `-Wmismatched-new-delete` compiler warning

## Test plan
- [x] Builds clean (warning gone)
- [ ] Run emulator, open memory dump window, verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)