### PR TITLE
Add n8mcp: MCP server for N8machine remote debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build/test/
 N8firmware*
 n8_kernel*
 n8_monitor*
+node_modules/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ make clean-test   # clean test artifacts only
 
 Run a single test by name: `./n8_test -tc="test name"`
 
-Dependencies: `libsdl2-dev`, OpenGL, `cc65` (firmware only), Node.js (n8gdb only).
+Dependencies: `libsdl2-dev`, OpenGL, `cc65` (firmware only), Node.js (n8gdb/n8mcp).
 
 Run the emulator from the repo root (it loads `N8firmware` and `N8firmware.sym` from CWD).
 
@@ -82,6 +82,69 @@ cc65 toolchain (`cl65 -t none --cpu 6502`). Linker config: `firmware/n8.cfg`. Cu
 
 Playground programs build to 8KB ROM binaries at $E000 with `.sym` files for n8gdb label resolution.
 
+## n8mcp — MCP Server
+
+`bin/n8mcp/n8mcp.mjs` — MCP server for AI-assisted debugging via Claude Code or other MCP clients. Connects to the GDB RSP stub over TCP, exposing 18 tools for emulator control.
+
+**Setup:** Install dependencies once: `cd bin/n8mcp && npm install`
+
+**Configuration** (`~/.claude/mcp.json`):
+```json
+{
+  "mcpServers": {
+    "n8machine": {
+      "command": "node",
+      "args": ["/path/to/N8machine/bin/n8mcp/n8mcp.mjs"],
+      "env": { "N8_HOME": "/path/to/N8machine" }
+    }
+  }
+}
+```
+
+**Tools:**
+
+| Tool | Description |
+|------|-------------|
+| `n8_start` | Start n8 emulator (no-op if running) |
+| `n8_stop` | Stop n8 emulator |
+| `n8_restart` | Restart n8 emulator |
+| `n8_regs` | Read all CPU registers with decoded flags |
+| `n8_write_reg` | Write a register by name (a/x/y/s/p/pc) |
+| `n8_status` | Show running/halted state + registers |
+| `n8_read_memory` | Read memory (hex dump + ASCII) |
+| `n8_write_memory` | Write hex bytes to memory |
+| `n8_load_binary` | Load binary file at address, optionally load .sym |
+| `n8_load_symbols` | Load cc65 .sym file for label resolution |
+| `n8_run` | Continue execution, wait for stop |
+| `n8_step` | Single-step N instructions |
+| `n8_halt` | Interrupt running program |
+| `n8_reset` | Reset CPU via reset vector |
+| `n8_goto` | Set PC and continue |
+| `n8_set_breakpoint` | Set breakpoint at address/label |
+| `n8_clear_breakpoint` | Clear breakpoint |
+| `n8_clear_all_breakpoints` | Clear all breakpoints/watchpoints |
+| `n8_kbd_inject` | Inject keystrokes (e.g. `go north[enter]`) |
+| `n8_console_text` | Read framebuffer as Unicode text |
+| `n8_console_video` | Capture screen as PNG screenshot |
+
+Read-only tools (`n8_regs`, `n8_read_memory`, `n8_status`, `n8_console_text`, `n8_console_video`, `n8_set_breakpoint`, `n8_clear_breakpoint`, `n8_clear_all_breakpoints`, `n8_kbd_inject`) auto-resume the CPU if it was running before the tool call.
+
+Env vars: `N8_HOME` (repo root, required for `n8_start`), `N8GDB_HOST`, `N8GDB_PORT`, `N8GDB_DEBUG`.
+
+Tests: `node bin/n8mcp/test.mjs` (131 tests, mock RSP server, no emulator needed).
+
+## Shared Modules
+
+`bin/shared/` — Reusable code imported by both n8gdb and n8mcp:
+
+| Module | Contents |
+|--------|----------|
+| `address.mjs` | `parseAddr()` — hex/decimal/label address parsing |
+| `symbols.mjs` | `loadSymbols()` — cc65 .sym file loader |
+| `format.mjs` | `hexdump()`, `fmtRegs()`, `fmtStop()`, `hex8()`, `hex16()` |
+| `charmap.mjs` | `N8_CHARMAP` — 256-entry byte-to-Unicode map |
+| `keyboard.mjs` | `parseKeyInput()`, `NAMED_KEYS`, `charToKeycode()` |
+
 ## Key Files
 
 | File | Purpose |
@@ -90,9 +153,12 @@ Playground programs build to 8KB ROM binaries at $E000 with `.sym` files for n8g
 | `src/emulator.cpp` | CPU core, 64KB memory, device router, breakpoint/watchpoint logic |
 | `src/n8_memory_map.h` | All hardware address constants and register definitions |
 | `src/gdb_stub.cpp` | GDB RSP protocol handler + TCP transport thread |
+| `src/gdb_bridge.cpp` | GDB-to-emulator callback bridge (zero coupling) |
 | `src/emu_tty.cpp` | TTY memory-mapped device (raw terminal I/O) |
 | `src/emu_video.cpp` | Video control registers, scroll, VID_DATA streaming |
 | `src/emu_kbd.cpp` | Keyboard registers, IRQ reassertion, key injection |
 | `src/m6502.h` | Vendored 6502 CPU emulator (do not edit) |
-| `bin/n8gdb/rsp.mjs` | Low-level GDB RSP TCP client |
+| `bin/n8gdb/rsp.mjs` | Low-level GDB RSP TCP client (shared by n8gdb + n8mcp) |
 | `bin/n8gdb/n8gdb.mjs` | n8gdb CLI commands and REPL |
+| `bin/n8mcp/n8mcp.mjs` | MCP server for AI-assisted debugging |
+| `bin/shared/` | Shared modules (address, symbols, format, charmap, keyboard) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ Tests: `node bin/n8mcp/test.mjs` (131 tests, mock RSP server, no emulator needed
 | `format.mjs` | `hexdump()`, `fmtRegs()`, `fmtStop()`, `hex8()`, `hex16()` |
 | `charmap.mjs` | `N8_CHARMAP` — 256-entry byte-to-Unicode map |
 | `keyboard.mjs` | `parseKeyInput()`, `NAMED_KEYS`, `charToKeycode()` |
+| `console.mjs` | `readConsoleText()` — read video regs + framebuffer as Unicode text |
 
 ## Key Files
 

--- a/bin/n8gdb/n8gdb.mjs
+++ b/bin/n8gdb/n8gdb.mjs
@@ -47,73 +47,26 @@ import { RspClient } from './rsp.mjs';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { createInterface } from 'readline';
 
+import { loadSymbols as _loadSymbols } from '../shared/symbols.mjs';
+import { parseAddr as _parseAddr } from '../shared/address.mjs';
+import { hexdump, fmtRegs as _fmtRegs, fmtStop as _fmtStop, hex8, hex16 } from '../shared/format.mjs';
+
 // ── Symbol table ────────────────────────────────────────────────
 
 const symbols = new Map();  // name -> addr
 const addrLabels = new Map();  // addr -> name[]
 
 function loadSymbols(path) {
-  const content = readFileSync(path, 'utf8');
-  let count = 0;
-  for (const line of content.split(/\r?\n/)) {
-    const m = line.match(/^al\s+([0-9a-fA-F]+)\s+\.(\S+)/);
-    if (m) {
-      const addr = parseInt(m[1], 16);
-      const name = m[2];
-      symbols.set(name, addr);
-      if (!addrLabels.has(addr)) addrLabels.set(addr, []);
-      addrLabels.get(addr).push(name);
-      count++;
-    }
-  }
-  return count;
+  return _loadSymbols(path, symbols, addrLabels);
 }
-
-// ── Address parsing ─────────────────────────────────────────────
 
 function parseAddr(str) {
-  if (!str) return NaN;
-  // Label lookup
-  if (symbols.has(str)) return symbols.get(str);
-  // Decimal with # prefix
-  if (str.startsWith('#')) return parseInt(str.slice(1), 10);
-  // Hex with prefix
-  if (str.startsWith('0x') || str.startsWith('0X')) return parseInt(str.slice(2), 16);
-  if (str.startsWith('$')) return parseInt(str.slice(1), 16);
-  // If it contains non-hex chars (without a prefix), it's likely a mistyped label
-  if (/[g-zG-Z_]/.test(str)) return NaN;
-  // Bare hex
-  return parseInt(str, 16);
-}
-
-// ── Output helpers ──────────────────────────────────────────────
-
-function hexdump(buf, baseAddr) {
-  const lines = [];
-  for (let off = 0; off < buf.length; off += 16) {
-    const slice = buf.subarray(off, Math.min(off + 16, buf.length));
-    const hex = Array.from(slice).map(b => b.toString(16).padStart(2, '0')).join(' ');
-    const ascii = Array.from(slice).map(b => (b >= 0x20 && b <= 0x7e) ? String.fromCharCode(b) : '.').join('');
-    const addr = (baseAddr + off).toString(16).padStart(4, '0');
-    lines.push(`${addr}: ${hex.padEnd(48)} ${ascii}`);
-  }
-  return lines.join('\n');
+  return _parseAddr(str, symbols);
 }
 
 function fmtRegs(r) {
-  const lines = [];
-  lines.push(`A:${hex8(r.a)}  X:${hex8(r.x)}  Y:${hex8(r.y)}  S:${hex8(r.s)}  P:${hex8(r.p)}  PC:${hex16(r.pc)}`);
-  const p = r.p;
-  const flags = `N${b(p,7)} V${b(p,6)} -${b(p,5)} B${b(p,4)} D${b(p,3)} I${b(p,2)} Z${b(p,1)} C${b(p,0)}`;
-  lines.push(`Flags: ${flags}`);
-  // Label at PC
-  if (addrLabels.has(r.pc)) lines.push(`  @ ${addrLabels.get(r.pc).join(', ')}`);
-  return lines.join('\n');
+  return _fmtRegs(r, addrLabels);
 }
-
-function hex8(v) { return v.toString(16).padStart(2, '0'); }
-function hex16(v) { return v.toString(16).padStart(4, '0'); }
-function b(v, bit) { return (v >> bit) & 1; }
 
 function fmtStop(reply) {
   if (!reply) return 'no reply';
@@ -274,60 +227,8 @@ async function cmdGoto(client, args) {
   await cmdRegs(client);
 }
 
-// ── N8 character map (byte → Unicode) ───────────────────────────
-
-// prettier-ignore
-const N8_CHARMAP = [
-  // $00-$0F
-  ' ',     '\u263A', '\u25CF', '\u2665', '\u2666', '\u2663', '\u2660', '\u2026',
-  '\u2713', '\u2717', '\u2605', '\u00DF', '\u2190', '\u2192', '\u2191', '\u2193',
-  // $10-$1F
-  '\u21B5', '\u21D0', '\u21D2', '\u21D1', '\u21D3', '\u25B6', '\u25C0', '\u25B2',
-  '\u25BC', '\u2194', '\u2195', '\u2302', '\u266A', '\u266B', '\u00A7', '\u00B6',
-  // $20-$7E: standard ASCII
-  ...Array.from({length: 95}, (_, i) => String.fromCharCode(0x20 + i)),
-  // $7F
-  '\u2310',
-  // $80-$8F: block elements
-  '\u2588', '\u2580', '\u2584', '\u258C', '\u2590', '\u2598', '\u259D', '\u2596',
-  '\u2597', '\u259A', '\u259E', '\u259B', '\u259C', '\u2599', '\u259F', '\u2591',
-  // $90-$9F: shading, thirds, diagonals
-  '\u2592', '\u2593', '\u2594', '\u2581', '\u258F', '\u2595', '\u2586', '\u2582',
-  '\u25E2', '\u25E3', '\u25E4', '\u25E5', '\u2571', '\u2572', '\u2573', '\u25AC',
-  // $A0-$AA: single-line box drawing
-  '\u2500', '\u2502', '\u250C', '\u2510', '\u2514', '\u2518', '\u251C', '\u2524',
-  '\u252C', '\u2534', '\u253C',
-  // $AB-$B5: heavy-line box drawing
-  '\u2501', '\u2503', '\u250F', '\u2513', '\u2517', '\u251B', '\u2523', '\u252B',
-  '\u2533', '\u253B', '\u254B',
-  // $B6-$B9: rounded corners
-  '\u256D', '\u256E', '\u2570', '\u256F',
-  // $BA-$BD: dashed
-  '\u254C', '\u254E', '\u254D', '\u254F',
-  // $BE-$BF: inverted punctuation
-  '\u00A1', '\u00BF',
-  // $C0-$CF: international
-  '\u00C0', '\u00C1', '\u00C4', '\u00C7', '\u00C9', '\u00D1', '\u00D6', '\u00DC',
-  '\u00E0', '\u00E1', '\u00E4', '\u00E7', '\u00E9', '\u00F1', '\u00F6', '\u00FC',
-  // $D0-$D9: geometric
-  '\u25CB', '\u25CE', '\u25A1', '\u25A0', '\u25B3', '\u25B7', '\u25BD', '\u25C1',
-  '\u25C7', '\u2606',
-  // $DA-$DF: dice
-  '\u2680', '\u2681', '\u2682', '\u2683', '\u2684', '\u2685',
-  // $E0-$EF: math/greek
-  '\u00B1', '\u00D7', '\u00F7', '\u2260', '\u2264', '\u2265', '\u2248', '\u00B0',
-  '\u221E', '\u221A', '\u03C0', '\u03A3', '\u03C3', '\u03BC', '\u03A9', '\u03B4',
-  // $F0-$F4: currency
-  '\u00A2', '\u00A3', '\u00A5', '\u20AC', '\u00A4',
-  // $F5-$F9: electronics
-  '\u23FB', '\u23DA', '\u26A1', '\u2316', '\u2318',
-  // $FA-$FB: copyright/registered
-  '\u00A9', '\u00AE',
-  // $FC-$FD: guillemets
-  '\u00AB', '\u00BB',
-  // $FE-$FF: N8 two-thirds blocks (closest Unicode approx)
-  '\u258A', '\u258E',
-];
+import { N8_CHARMAP } from '../shared/charmap.mjs';
+import { parseKeyInput, NAMED_KEYS, charToKeycode } from '../shared/keyboard.mjs';
 
 // ── Console text ────────────────────────────────────────────────
 
@@ -433,34 +334,9 @@ function cmdHelp() {
   ].join('\n'));
 }
 
-// ── Named keys and auto-modifier tables ─────────────────────────
-
-const NAMED_KEYS = {
-  enter: 0x0D, return: 0x0D, cr: 0x0D,
-  backspace: 0x08, bs: 0x08,
-  tab: 0x09,
-  esc: 0x1B, escape: 0x1B,
-  delete: 0x0F, del: 0x0F,
-  space: 0x20,
-  up: 0x01, down: 0x02, left: 0x03, right: 0x04,
-  home: 0x05, end: 0x06, pageup: 0x0A, pagedown: 0x0B, insert: 0x0E,
-  printscreen: 0x10, pause: 0x11,
-  f1: 0x80, f2: 0x81, f3: 0x82, f4: 0x83, f5: 0x84, f6: 0x85,
-  f7: 0x86, f8: 0x87, f9: 0x88, f10: 0x89, f11: 0x8A, f12: 0x8B,
-};
-
-function charToKeycode(ch) {
-  const code = ch.charCodeAt(0);
-  // Printable ASCII $20-$7E: send ASCII code directly as keycode
-  // (N8 keycode space includes the full printable ASCII range)
-  if (code >= 0x20 && code <= 0x7E) {
-    return { keycode: code, modifiers: 0x00 };
-  }
-  return null;
-}
+// ── Keyboard injection ──────────────────────────────────────────
 
 async function cmdKbdInject(client, args) {
-  // Parse modifier flags
   let extraMod = 0;
   const inputArgs = [];
   for (let i = 0; i < args.length; i++) {
@@ -483,49 +359,8 @@ async function cmdKbdInject(client, args) {
   }
 
   const input = inputArgs.join(' ');
-  const keys = [];  // [{keycode, modifiers}, ...]
-
-  // Parse input as inline text with [named_key] and [0xNN] sequences.
-  // Bare text characters are sent as ASCII keycodes.
-  // [enter], [backspace], [up], [0x41], etc. insert named/hex keys inline.
-  let i = 0;
-  while (i < input.length) {
-    if (input[i] === '\\' && i + 1 < input.length && input[i + 1] === 'n') {
-      keys.push({ keycode: 0x0D, modifiers: extraMod });
-      i += 2;
-    } else if (input[i] === '[') {
-      const close = input.indexOf(']', i + 1);
-      if (close === -1) {
-        // No closing bracket — treat '[' as literal char
-        const kc = charToKeycode(input[i]);
-        if (!kc) { console.error(`Cannot map character: ${input[i]}`); return; }
-        keys.push({ keycode: kc.keycode, modifiers: kc.modifiers | extraMod });
-        i++;
-        continue;
-      }
-      const tag = input.slice(i + 1, close);
-      const tagLower = tag.toLowerCase();
-      if (tagLower in NAMED_KEYS) {
-        keys.push({ keycode: NAMED_KEYS[tagLower], modifiers: extraMod });
-      } else {
-        // Try hex keycode: [0x41] or [$41]
-        const addr = parseAddr(tag);
-        if (!isNaN(addr) && addr <= 0xFF) {
-          keys.push({ keycode: addr, modifiers: extraMod });
-        } else {
-          console.error(`Unknown key name: [${tag}]`);
-          return;
-        }
-      }
-      i = close + 1;
-    } else {
-      const kc = charToKeycode(input[i]);
-      if (!kc) { console.error(`Cannot map character: ${input[i]}`); return; }
-      keys.push({ keycode: kc.keycode, modifiers: kc.modifiers | extraMod });
-      i++;
-    }
-  }
-
+  const { keys, error } = parseKeyInput(input, extraMod, parseAddr);
+  if (error) { console.error(error); return; }
   if (keys.length === 0) { console.error('No keys to inject'); return; }
   if (keys.length > 32) {
     console.error(`Too many keys (${keys.length}): limit is 32 to avoid keyboard buffer overflow`);

--- a/bin/n8gdb/n8gdb.mjs
+++ b/bin/n8gdb/n8gdb.mjs
@@ -71,9 +71,9 @@ function fmtRegs(r) {
 function fmtStop(reply) {
   if (!reply) return 'no reply';
   if (reply.startsWith('T05')) {
-    if (reply.includes('watch:')) return `watchpoint (write) hit — ${reply}`;
-    if (reply.includes('rwatch:')) return `watchpoint (read) hit — ${reply}`;
     if (reply.includes('awatch:')) return `watchpoint (access) hit — ${reply}`;
+    if (reply.includes('rwatch:')) return `watchpoint (read) hit — ${reply}`;
+    if (reply.includes('watch:')) return `watchpoint (write) hit — ${reply}`;
     return `breakpoint hit — ${reply}`;
   }
   if (reply.startsWith('T')) return `stopped signal ${parseInt(reply.slice(1, 3), 16)} — ${reply}`;
@@ -229,43 +229,12 @@ async function cmdGoto(client, args) {
 
 import { N8_CHARMAP } from '../shared/charmap.mjs';
 import { parseKeyInput, NAMED_KEYS, charToKeycode } from '../shared/keyboard.mjs';
+import { readConsoleText } from '../shared/console.mjs';
 
 // ── Console text ────────────────────────────────────────────────
 
 async function cmdConsoleText(client) {
-  // Read video registers at $D840 (9 bytes: mode..vsync)
-  const regs = await client.readMemory(0xD840, 9);
-  const mode   = regs[0];
-  const width  = regs[1];
-  const height = regs[2];
-  const stride = regs[3];
-  const curStyle = regs[5];
-  const curCol   = regs[6];
-  const curRow   = regs[7];
-
-  const fbSize = stride * height;
-  if (fbSize === 0 || fbSize > 0x1000) {
-    console.error('Invalid video dimensions');
-    return;
-  }
-
-  const fb = await client.readMemory(0xC000, fbSize);
-
-  const modeStr = mode === 0 ? 'Text Default' : mode === 1 ? 'Text Custom' : `0x${hex8(mode)}`;
-  const curModeStr = (curStyle & 0x03) === 0 ? 'off' : (curStyle & 0x03) === 1 ? 'steady' : 'flash';
-  const curShapeStr = (curStyle & 0x0C) === 0x04 ? 'block' : 'underline';
-  console.log(`Mode: ${modeStr}  Size: ${width}\u00D7${height}  Stride: ${stride}  Cursor: (${curCol},${curRow}) ${curModeStr} ${curShapeStr}`);
-  console.log('\u2500'.repeat(width));
-
-  for (let row = 0; row < height; row++) {
-    let line = '';
-    for (let col = 0; col < width; col++) {
-      const byte = fb[row * stride + col];
-      line += N8_CHARMAP[byte] || '?';
-    }
-    console.log(line);
-  }
-  console.log('\u2500'.repeat(width));
+  console.log(await readConsoleText(client));
 }
 
 // ── Console video ────────────────────────────────────────────────

--- a/bin/n8mcp/n8mcp.mjs
+++ b/bin/n8mcp/n8mcp.mjs
@@ -1,0 +1,621 @@
+#!/usr/bin/env node
+
+/**
+ * n8mcp — MCP server for N8machine 6502 emulator.
+ *
+ * Provides tool-based access to the N8machine emulator via GDB RSP protocol.
+ * Designed for use with Claude Code and other MCP clients.
+ *
+ * Environment:
+ *   N8_HOME       Path to N8machine repo root (required for n8_start)
+ *   N8GDB_HOST    GDB stub host (default: 127.0.0.1)
+ *   N8GDB_PORT    GDB stub port (default: 3333)
+ *   N8GDB_DEBUG   Set to 1 for RSP debug logging
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { spawn } from 'child_process';
+import { createConnection } from 'net';
+
+import { RspClient } from '../n8gdb/rsp.mjs';
+import { loadSymbols } from '../shared/symbols.mjs';
+import { parseAddr } from '../shared/address.mjs';
+import { hexdump, fmtRegs, fmtStop, hex8, hex16 } from '../shared/format.mjs';
+import { N8_CHARMAP } from '../shared/charmap.mjs';
+import { parseKeyInput } from '../shared/keyboard.mjs';
+
+// ── State ────────────────────────────────────────────────────────
+
+let client = null;
+let n8Process = null;
+const symbols = new Map();
+const addrLabels = new Map();
+
+const HOST = process.env.N8GDB_HOST || '127.0.0.1';
+const PORT = parseInt(process.env.N8GDB_PORT || '3333', 10);
+const N8_HOME = process.env.N8_HOME || null;
+
+// ── Connection management ────────────────────────────────────────
+
+async function ensureConnected() {
+  if (client?.connected) return;
+  client = new RspClient();
+  await client.connect(HOST, PORT);
+}
+
+function resolveAddr(str) {
+  return parseAddr(str, symbols);
+}
+
+/**
+ * Execute a read-only operation that auto-resumes the CPU if it was running.
+ */
+async function withAutoResume(fn) {
+  await ensureConnected();
+  const wasRunning = client.wasRunning;
+  try {
+    return await fn(client);
+  } finally {
+    if (wasRunning) client.continueAsync();
+  }
+}
+
+/**
+ * Execute an operation that does NOT auto-resume (mutating operations).
+ */
+async function withConnection(fn) {
+  await ensureConnected();
+  return await fn(client);
+}
+
+// ── Process management ───────────────────────────────────────────
+
+function isPortOpen(host, port, timeoutMs = 1000) {
+  return new Promise((resolve) => {
+    const sock = createConnection({ host, port }, () => {
+      sock.destroy();
+      resolve(true);
+    });
+    sock.on('error', () => resolve(false));
+    sock.setTimeout(timeoutMs, () => { sock.destroy(); resolve(false); });
+  });
+}
+
+async function waitForPort(host, port, maxWaitMs = 10000) {
+  const start = Date.now();
+  while (Date.now() - start < maxWaitMs) {
+    if (await isPortOpen(host, port)) return true;
+    await new Promise(r => setTimeout(r, 250));
+  }
+  return false;
+}
+
+async function findN8Pid() {
+  try {
+    const { execSync } = await import('child_process');
+    const out = execSync(`lsof -ti :${PORT} 2>/dev/null`, { encoding: 'utf8' }).trim();
+    return out ? parseInt(out.split('\n')[0], 10) : null;
+  } catch { return null; }
+}
+
+async function startN8() {
+  if (await isPortOpen(HOST, PORT)) {
+    return { alreadyRunning: true, pid: await findN8Pid() };
+  }
+  if (!N8_HOME) {
+    throw new Error('N8_HOME environment variable not set. Cannot start n8.');
+  }
+  if (!existsSync(`${N8_HOME}/n8`) && !existsSync(`${N8_HOME}/build/n8`)) {
+    throw new Error(`n8 binary not found in ${N8_HOME}. Run 'make' first.`);
+  }
+  const binary = existsSync(`${N8_HOME}/n8`) ? './n8' : './build/n8';
+
+  // Disconnect existing client if any
+  if (client?.connected) { client.disconnect(); client = null; }
+
+  n8Process = spawn(binary, [], {
+    cwd: N8_HOME,
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env },
+  });
+  n8Process.unref();
+  const pid = n8Process.pid;
+
+  const ready = await waitForPort(HOST, PORT);
+  if (!ready) {
+    throw new Error(`n8 started (PID ${pid}) but port ${PORT} not ready after 10s`);
+  }
+  return { alreadyRunning: false, pid };
+}
+
+async function stopN8() {
+  if (client?.connected) { client.disconnect(); client = null; }
+
+  const pid = n8Process?.pid || await findN8Pid();
+  if (!pid) {
+    throw new Error('No n8 process found');
+  }
+  try {
+    process.kill(pid, 'SIGTERM');
+  } catch (e) {
+    if (e.code === 'ESRCH') throw new Error(`Process ${pid} not found`);
+    throw e;
+  }
+  n8Process = null;
+
+  // Wait for port to close
+  const start = Date.now();
+  while (Date.now() - start < 5000) {
+    if (!(await isPortOpen(HOST, PORT))) return pid;
+    await new Promise(r => setTimeout(r, 250));
+  }
+  return pid;
+}
+
+// ── Console text helper ──────────────────────────────────────────
+
+async function readConsoleText(rsp) {
+  const regs = await rsp.readMemory(0xD840, 12);
+  const mode   = regs[0];
+  const width  = regs[1];
+  const height = regs[2];
+  const stride = regs[3];
+  const curStyle = regs[5];
+  const curCol   = regs[6];
+  const curRow   = regs[7];
+
+  const fbSize = stride * height;
+  if (fbSize === 0 || fbSize > 0x1000) {
+    throw new Error(`Invalid video dimensions: ${width}x${height} stride=${stride}`);
+  }
+
+  const fb = await rsp.readMemory(0xC000, fbSize);
+
+  const modeStr = mode === 0 ? 'Text Default' : mode === 1 ? 'Text Custom' : `0x${hex8(mode)}`;
+  const curModeStr = (curStyle & 0x03) === 0 ? 'off' : (curStyle & 0x03) === 1 ? 'steady' : 'flash';
+  const curShapeStr = (curStyle & 0x0C) === 0x04 ? 'block' : 'underline';
+
+  const lines = [];
+  lines.push(`Mode: ${modeStr}  Size: ${width}\u00D7${height}  Stride: ${stride}  Cursor: (${curCol},${curRow}) ${curModeStr} ${curShapeStr}`);
+  lines.push('\u2500'.repeat(width));
+
+  for (let row = 0; row < height; row++) {
+    let line = '';
+    for (let col = 0; col < width; col++) {
+      const byte = fb[row * stride + col];
+      line += N8_CHARMAP[byte] || '?';
+    }
+    lines.push(line);
+  }
+  lines.push('\u2500'.repeat(width));
+  return lines.join('\n');
+}
+
+// ── MCP Server ───────────────────────────────────────────────────
+
+const server = new McpServer({
+  name: 'n8machine',
+  version: '1.0.0',
+});
+
+// -- Process management --
+
+server.tool('n8_start', 'Start the N8machine emulator. No-op if already running.', {},
+  async () => {
+    try {
+      const result = await startN8();
+      if (result.alreadyRunning) {
+        return { content: [{ type: 'text', text: `n8 already running (PID ${result.pid || 'unknown'})` }] };
+      }
+      return { content: [{ type: 'text', text: `n8 started (PID ${result.pid}), port ${PORT} ready` }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_stop', 'Stop the N8machine emulator.', {},
+  async () => {
+    try {
+      const pid = await stopN8();
+      return { content: [{ type: 'text', text: `n8 stopped (PID ${pid})` }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_restart', 'Restart the N8machine emulator.', {},
+  async () => {
+    try {
+      try { await stopN8(); } catch { /* may not be running */ }
+      await new Promise(r => setTimeout(r, 500));
+      const result = await startN8();
+      return { content: [{ type: 'text', text: `n8 restarted (PID ${result.pid}), port ${PORT} ready` }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+// -- CPU state --
+
+server.tool('n8_regs', 'Read all 6502 CPU registers (A, X, Y, S, P, PC) with decoded flags. Auto-resumes if CPU was running.', {},
+  async () => {
+    try {
+      const text = await withAutoResume(async (rsp) => {
+        const r = await rsp.readRegisters();
+        return fmtRegs(r, addrLabels);
+      });
+      return { content: [{ type: 'text', text }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_write_reg',
+  'Write a CPU register by name. Returns updated registers.',
+  { register: z.enum(['a', 'x', 'y', 's', 'p', 'pc']).describe('Register name'), value: z.string().describe('Value (hex with 0x/$, decimal with #, or bare hex)') },
+  async ({ register, value }) => {
+    try {
+      const REG_IDS = { a: 0, x: 1, y: 2, s: 3, pc: 4, p: 5 };
+      const id = REG_IDS[register];
+      const val = resolveAddr(value);
+      if (isNaN(val)) return { content: [{ type: 'text', text: `Invalid value: ${value}` }], isError: true };
+
+      const text = await withConnection(async (rsp) => {
+        await rsp.writeRegister(id, val);
+        const r = await rsp.readRegisters();
+        const width = id === 4 ? 4 : 2;
+        return `${register.toUpperCase()} = $${val.toString(16).padStart(width, '0')}\n${fmtRegs(r, addrLabels)}`;
+      });
+      return { content: [{ type: 'text', text }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_status',
+  'Show CPU state (running/halted + registers) without changing execution state. Auto-resumes if CPU was running.',
+  {},
+  async () => {
+    try {
+      const text = await withAutoResume(async (rsp) => {
+        const state = rsp.wasRunning ? 'Running' : 'Halted';
+        const r = await rsp.readRegisters();
+        return `CPU: ${state}\n${fmtRegs(r, addrLabels)}`;
+      });
+      return { content: [{ type: 'text', text }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+// -- Memory --
+
+server.tool('n8_read_memory',
+  'Read memory. Returns hex dump with ASCII. Accepts labels if symbols loaded. Auto-resumes.',
+  { address: z.string().describe('Address (hex, label, or decimal with #)'), length: z.number().default(16).describe('Number of bytes to read (default 16)') },
+  async ({ address, length }) => {
+    try {
+      const addr = resolveAddr(address);
+      if (isNaN(addr)) return { content: [{ type: 'text', text: `Invalid address: ${address}` }], isError: true };
+
+      const text = await withAutoResume(async (rsp) => {
+        const buf = await rsp.readMemory(addr, length);
+        return hexdump(buf, addr);
+      });
+      return { content: [{ type: 'text', text }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_write_memory',
+  'Write hex bytes to a memory address.',
+  { address: z.string().describe('Address (hex, label, or decimal with #)'), hex_data: z.string().describe('Hex string of bytes to write (e.g. "a9428d00")') },
+  async ({ address, hex_data }) => {
+    try {
+      const addr = resolveAddr(address);
+      if (isNaN(addr)) return { content: [{ type: 'text', text: `Invalid address: ${address}` }], isError: true };
+      const clean = hex_data.replace(/[\s,]/g, '');
+      if (clean.length === 0) return { content: [{ type: 'text', text: 'Empty hex string' }], isError: true };
+      if (clean.length % 2 !== 0) return { content: [{ type: 'text', text: 'Hex string must have even number of digits' }], isError: true };
+      if (!/^[0-9a-fA-F]+$/.test(clean)) return { content: [{ type: 'text', text: 'Invalid hex characters' }], isError: true };
+
+      const data = Buffer.from(clean, 'hex');
+      const text = await withConnection(async (rsp) => {
+        await rsp.writeMemory(addr, data);
+        return `Wrote ${data.length} bytes at $${hex16(addr)}`;
+      });
+      return { content: [{ type: 'text', text }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_load_binary',
+  'Load a binary file into memory at the given address. Optionally load a .sym file for labels.',
+  { file: z.string().describe('Path to binary file'), address: z.string().describe('Load address (hex, decimal with #)'), sym_file: z.string().optional().describe('Path to .sym file for label resolution') },
+  async ({ file, address, sym_file }) => {
+    try {
+      const addr = resolveAddr(address);
+      if (isNaN(addr)) return { content: [{ type: 'text', text: `Invalid address: ${address}` }], isError: true };
+      if (!existsSync(file)) return { content: [{ type: 'text', text: `File not found: ${file}` }], isError: true };
+
+      const data = readFileSync(file);
+      const lines = [];
+
+      if (sym_file) {
+        if (!existsSync(sym_file)) return { content: [{ type: 'text', text: `Symbol file not found: ${sym_file}` }], isError: true };
+        const count = loadSymbols(sym_file, symbols, addrLabels);
+        lines.push(`Loaded ${count} symbols from ${sym_file}`);
+      }
+
+      await withConnection(async (rsp) => {
+        await rsp.writeMemory(addr, data);
+      });
+      lines.push(`Loaded ${data.length} bytes from ${file} at $${hex16(addr)}`);
+      return { content: [{ type: 'text', text: lines.join('\n') }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+// -- Symbols --
+
+server.tool('n8_load_symbols',
+  'Load a cc65 .sym file for label-based address resolution. Persists for the session.',
+  { file: z.string().describe('Path to .sym file') },
+  async ({ file }) => {
+    try {
+      if (!existsSync(file)) return { content: [{ type: 'text', text: `File not found: ${file}` }], isError: true };
+      const count = loadSymbols(file, symbols, addrLabels);
+      const listing = Array.from(symbols.entries()).map(([name, addr]) => `  $${hex16(addr)}  ${name}`).join('\n');
+      return { content: [{ type: 'text', text: `Loaded ${count} symbols:\n${listing}` }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+// -- Execution control --
+
+server.tool('n8_run',
+  'Continue execution and wait for a breakpoint, watchpoint, or timeout.',
+  { timeout_ms: z.number().default(5000).describe('Timeout in milliseconds (default 5000)') },
+  async ({ timeout_ms }) => {
+    try {
+      const text = await withConnection(async (rsp) => {
+        const reply = await rsp.continue(timeout_ms);
+        const r = await rsp.readRegisters();
+        return `${fmtStop(reply)}\n${fmtRegs(r, addrLabels)}`;
+      });
+      return { content: [{ type: 'text', text }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_step',
+  'Single-step the CPU. Returns registers after stepping.',
+  { count: z.number().default(1).describe('Number of instructions to step (default 1)') },
+  async ({ count }) => {
+    try {
+      const text = await withConnection(async (rsp) => {
+        let lastReply;
+        for (let i = 0; i < count; i++) {
+          lastReply = await rsp.step();
+          if (!lastReply.startsWith('T05') && !lastReply.startsWith('S05')) break;
+        }
+        const r = await rsp.readRegisters();
+        return `${fmtStop(lastReply)} (${count} step${count > 1 ? 's' : ''})\n${fmtRegs(r, addrLabels)}`;
+      });
+      return { content: [{ type: 'text', text }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_halt',
+  'Interrupt a running program. Returns registers.',
+  {},
+  async () => {
+    try {
+      const text = await withConnection(async (rsp) => {
+        const reply = await rsp.pause();
+        const r = await rsp.readRegisters();
+        return `${fmtStop(reply)}\n${fmtRegs(r, addrLabels)}`;
+      });
+      return { content: [{ type: 'text', text }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_reset',
+  'Reset the CPU by reading the reset vector and setting PC. Returns registers.',
+  {},
+  async () => {
+    try {
+      const text = await withConnection(async (rsp) => {
+        const vec = await rsp.readMemory(0xFFFC, 2);
+        const resetAddr = vec[0] | (vec[1] << 8);
+        await rsp.writeRegister(4, resetAddr);
+        const r = await rsp.readRegisters();
+        return `Reset: PC set to $${hex16(resetAddr)} (from reset vector)\n${fmtRegs(r, addrLabels)}`;
+      });
+      return { content: [{ type: 'text', text }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_goto',
+  'Set PC to an address and continue execution. Waits for stop.',
+  { address: z.string().describe('Address or label'), timeout_ms: z.number().default(5000).describe('Timeout in milliseconds (default 5000)') },
+  async ({ address, timeout_ms }) => {
+    try {
+      const addr = resolveAddr(address);
+      if (isNaN(addr)) return { content: [{ type: 'text', text: `Invalid address: ${address}` }], isError: true };
+      const label = addrLabels.has(addr) ? ` (${addrLabels.get(addr).join(', ')})` : '';
+
+      const text = await withConnection(async (rsp) => {
+        await rsp.writeRegister(4, addr);
+        const reply = await rsp.continue(timeout_ms);
+        const r = await rsp.readRegisters();
+        return `Goto $${hex16(addr)}${label}\n${fmtStop(reply)}\n${fmtRegs(r, addrLabels)}`;
+      });
+      return { content: [{ type: 'text', text }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+// -- Breakpoints --
+
+server.tool('n8_set_breakpoint',
+  'Set an execution breakpoint at an address or label.',
+  { address: z.string().describe('Address or label') },
+  async ({ address }) => {
+    try {
+      const addr = resolveAddr(address);
+      if (isNaN(addr)) return { content: [{ type: 'text', text: `Invalid address: ${address}` }], isError: true };
+      const label = addrLabels.has(addr) ? ` (${addrLabels.get(addr).join(', ')})` : '';
+
+      await withAutoResume(async (rsp) => {
+        await rsp.setBreakpoint(addr);
+      });
+      return { content: [{ type: 'text', text: `Breakpoint set at $${hex16(addr)}${label}` }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_clear_breakpoint',
+  'Clear a breakpoint at an address or label.',
+  { address: z.string().describe('Address or label') },
+  async ({ address }) => {
+    try {
+      const addr = resolveAddr(address);
+      if (isNaN(addr)) return { content: [{ type: 'text', text: `Invalid address: ${address}` }], isError: true };
+
+      await withAutoResume(async (rsp) => {
+        await rsp.clearBreakpoint(addr);
+      });
+      return { content: [{ type: 'text', text: `Breakpoint cleared at $${hex16(addr)}` }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_clear_all_breakpoints',
+  'Clear all breakpoints and watchpoints.',
+  {},
+  async () => {
+    try {
+      await withAutoResume(async (rsp) => {
+        await rsp.monitorCommand('clear-bp');
+      });
+      return { content: [{ type: 'text', text: 'Cleared all breakpoints and watchpoints' }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+// -- I/O --
+
+server.tool('n8_kbd_inject',
+  'Inject keystrokes into the N8 keyboard buffer. Syntax: bare text with [named_key] sequences. Example: "go north[enter]". Named keys: enter, esc, tab, backspace, delete, space, up, down, left, right, home, end, pageup, pagedown, insert, f1-f12. Hex keycodes: [0xNN]. Max 32 keys.',
+  { text: z.string().describe('Key string with inline [named_key] sequences'), shift: z.boolean().default(false), ctrl: z.boolean().default(false), alt: z.boolean().default(false) },
+  async ({ text, shift, ctrl, alt }) => {
+    try {
+      let extraMod = 0;
+      if (shift) extraMod |= 0x04;
+      if (ctrl) extraMod |= 0x08;
+      if (alt) extraMod |= 0x10;
+
+      const { keys, error } = parseKeyInput(text, extraMod, resolveAddr);
+      if (error) return { content: [{ type: 'text', text: `Error: ${error}` }], isError: true };
+      if (keys.length === 0) return { content: [{ type: 'text', text: 'No keys to inject' }], isError: true };
+      if (keys.length > 32) return { content: [{ type: 'text', text: `Too many keys (${keys.length}): limit is 32` }], isError: true };
+
+      await withAutoResume(async (rsp) => {
+        for (const { keycode, modifiers } of keys) {
+          const reply = await rsp.monitorCommand(`kbd ${hex8(keycode)} ${hex8(modifiers)}`);
+          if (reply !== 'OK') throw new Error(`kbd_inject failed: ${reply}`);
+        }
+      });
+      return { content: [{ type: 'text', text: `Injected ${keys.length} key${keys.length > 1 ? 's' : ''}` }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_console_text',
+  'Read the video framebuffer as Unicode text using the N8 character map. Shows video mode, dimensions, cursor position, and full screen content. Auto-resumes.',
+  {},
+  async () => {
+    try {
+      const text = await withAutoResume(async (rsp) => {
+        return await readConsoleText(rsp);
+      });
+      return { content: [{ type: 'text', text }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+server.tool('n8_console_video',
+  'Capture the emulator screen as a PNG screenshot. Saves to the specified path and returns it.',
+  { path: z.string().describe('File path to save the PNG screenshot') },
+  async ({ path }) => {
+    try {
+      const result = await withAutoResume(async (rsp) => {
+        const hexData = await rsp.readXfer('n8screen');
+        const png = Buffer.from(hexData, 'hex');
+        writeFileSync(path, png);
+        return { size: png.length, path };
+      });
+      return { content: [{ type: 'text', text: `Screenshot saved: ${result.path} (${result.size} bytes)` }] };
+    } catch (e) {
+      return { content: [{ type: 'text', text: `Error: ${e.message}` }], isError: true };
+    }
+  }
+);
+
+// ── Start server ─────────────────────────────────────────────────
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  console.error(`n8mcp fatal: ${err.message}`);
+  process.exit(1);
+});
+
+// Export for testing
+export { server, ensureConnected, resolveAddr, withAutoResume, withConnection,
+         readConsoleText, startN8, stopN8, isPortOpen, symbols, addrLabels };

--- a/bin/n8mcp/n8mcp.mjs
+++ b/bin/n8mcp/n8mcp.mjs
@@ -24,8 +24,8 @@ import { RspClient } from '../n8gdb/rsp.mjs';
 import { loadSymbols } from '../shared/symbols.mjs';
 import { parseAddr } from '../shared/address.mjs';
 import { hexdump, fmtRegs, fmtStop, hex8, hex16 } from '../shared/format.mjs';
-import { N8_CHARMAP } from '../shared/charmap.mjs';
 import { parseKeyInput } from '../shared/keyboard.mjs';
+import { readConsoleText } from '../shared/console.mjs';
 
 // ── State ────────────────────────────────────────────────────────
 
@@ -56,11 +56,9 @@ function resolveAddr(str) {
 async function withAutoResume(fn) {
   await ensureConnected();
   const wasRunning = client.wasRunning;
-  try {
-    return await fn(client);
-  } finally {
-    if (wasRunning) client.continueAsync();
-  }
+  const result = await fn(client);
+  if (wasRunning) client.continueAsync();
+  return result;
 }
 
 /**
@@ -154,45 +152,6 @@ async function stopN8() {
     await new Promise(r => setTimeout(r, 250));
   }
   return pid;
-}
-
-// ── Console text helper ──────────────────────────────────────────
-
-async function readConsoleText(rsp) {
-  const regs = await rsp.readMemory(0xD840, 12);
-  const mode   = regs[0];
-  const width  = regs[1];
-  const height = regs[2];
-  const stride = regs[3];
-  const curStyle = regs[5];
-  const curCol   = regs[6];
-  const curRow   = regs[7];
-
-  const fbSize = stride * height;
-  if (fbSize === 0 || fbSize > 0x1000) {
-    throw new Error(`Invalid video dimensions: ${width}x${height} stride=${stride}`);
-  }
-
-  const fb = await rsp.readMemory(0xC000, fbSize);
-
-  const modeStr = mode === 0 ? 'Text Default' : mode === 1 ? 'Text Custom' : `0x${hex8(mode)}`;
-  const curModeStr = (curStyle & 0x03) === 0 ? 'off' : (curStyle & 0x03) === 1 ? 'steady' : 'flash';
-  const curShapeStr = (curStyle & 0x0C) === 0x04 ? 'block' : 'underline';
-
-  const lines = [];
-  lines.push(`Mode: ${modeStr}  Size: ${width}\u00D7${height}  Stride: ${stride}  Cursor: (${curCol},${curRow}) ${curModeStr} ${curShapeStr}`);
-  lines.push('\u2500'.repeat(width));
-
-  for (let row = 0; row < height; row++) {
-    let line = '';
-    for (let col = 0; col < width; col++) {
-      const byte = fb[row * stride + col];
-      line += N8_CHARMAP[byte] || '?';
-    }
-    lines.push(line);
-  }
-  lines.push('\u2500'.repeat(width));
-  return lines.join('\n');
 }
 
 // ── MCP Server ───────────────────────────────────────────────────
@@ -618,4 +577,4 @@ main().catch((err) => {
 
 // Export for testing
 export { server, ensureConnected, resolveAddr, withAutoResume, withConnection,
-         readConsoleText, startN8, stopN8, isPortOpen, symbols, addrLabels };
+         startN8, stopN8, isPortOpen, symbols, addrLabels };

--- a/bin/n8mcp/package-lock.json
+++ b/bin/n8mcp/package-lock.json
@@ -1,0 +1,1141 @@
+{
+  "name": "n8mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "n8mcp",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1"
+      },
+      "bin": {
+        "n8mcp": "n8mcp.mjs"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
+      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.0.tgz",
+      "integrity": "sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/bin/n8mcp/package.json
+++ b/bin/n8mcp/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "n8mcp",
+  "version": "1.0.0",
+  "description": "MCP server for N8machine 6502 emulator",
+  "type": "module",
+  "bin": {
+    "n8mcp": "./n8mcp.mjs"
+  },
+  "scripts": {
+    "test": "node test.mjs"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1"
+  }
+}

--- a/bin/n8mcp/package.json
+++ b/bin/n8mcp/package.json
@@ -10,6 +10,7 @@
     "test": "node test.mjs"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1"
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "zod": "^3.25 || ^4.0"
   }
 }

--- a/bin/n8mcp/test.mjs
+++ b/bin/n8mcp/test.mjs
@@ -706,6 +706,66 @@ async function testAutoResumeNotRunning() {
   mock.close();
 }
 
+async function testAutoResumeOnError() {
+  currentTest = 'mcp:auto_resume_on_error';
+  // When fn throws, withAutoResume should NOT resume the CPU.
+  // The CPU stays halted so the user can investigate.
+  const mock = await createMockServer(new Map([
+    ['qSupported', 'PacketSize=4000;swbreak+;hwbreak+'],
+    ['QStartNoAckMode', 'OK'],
+    ['?', 'T00thread:01;'],  // T00 = was running
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+  assert(client.wasRunning, 'wasRunning should be true');
+
+  // Simulate withAutoResume where fn throws
+  const wasRunning = client.wasRunning;
+  let threw = false;
+  try {
+    await (async () => { throw new Error('simulated tool failure'); })();
+  } catch {
+    threw = true;
+  }
+  assert(threw, 'fn threw as expected');
+
+  // The key assertion: continueAsync should NOT have been called.
+  // We verify by checking that no 'c' command was sent.
+  assert(!mock.received.includes('c'), 'no continue sent on error');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testSharedReadConsoleText() {
+  currentTest = 'shared:readConsoleText';
+
+  // Video regs (12 bytes) and framebuffer via mock
+  const videoRegsHex = '002802280001050100000000';
+  const row1 = '48656c6c6f' + '00'.repeat(35);
+  const row2 = '00'.repeat(40);
+
+  const mock = await mockWithHandshake(new Map([
+    ['md840', videoRegsHex],
+    ['mc000', row1 + row2],
+  ]));
+
+  const { readConsoleText: sharedReadConsoleText } = await import('../shared/console.mjs');
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  const text = await sharedReadConsoleText(client);
+  assert(text.includes('Text Default'), 'mode label');
+  assert(text.includes('40\u00D72'), 'dimensions');
+  assert(text.includes('Hello'), 'framebuffer content');
+  assert(text.includes('(5,1)'), 'cursor position');
+
+  client.disconnect();
+  mock.close();
+}
+
 async function testSymbolAddressResolution() {
   currentTest = 'mcp:symbol_address_resolution';
 
@@ -876,6 +936,8 @@ async function main() {
     testMcpGoto,
     testAutoResume,
     testAutoResumeNotRunning,
+    testAutoResumeOnError,
+    testSharedReadConsoleText,
     testSymbolAddressResolution,
     testMcpLoadBinary,
     testMonitorCommand,

--- a/bin/n8mcp/test.mjs
+++ b/bin/n8mcp/test.mjs
@@ -1,0 +1,899 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for n8mcp MCP server.
+ * Tests shared modules, tool handler logic, and mock RSP interactions.
+ */
+
+import { createServer } from 'net';
+import { readFileSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Shared modules under test
+import { parseAddr } from '../shared/address.mjs';
+import { loadSymbols } from '../shared/symbols.mjs';
+import { hexdump, fmtRegs, fmtStop, hex8, hex16 } from '../shared/format.mjs';
+import { N8_CHARMAP } from '../shared/charmap.mjs';
+import { parseKeyInput, NAMED_KEYS, charToKeycode } from '../shared/keyboard.mjs';
+
+// RSP client for mock server tests
+import { RspClient } from '../n8gdb/rsp.mjs';
+
+let passed = 0;
+let failed = 0;
+let currentTest = '';
+
+function assert(cond, msg) {
+  if (cond) { passed++; }
+  else { failed++; console.error(`  FAIL [${currentTest}]: ${msg}`); }
+}
+
+function assertEq(a, b, msg) {
+  if (a === b) { passed++; }
+  else { failed++; console.error(`  FAIL [${currentTest}]: ${msg}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}`); }
+}
+
+function assertMatch(str, pattern, msg) {
+  if (pattern.test(str)) { passed++; }
+  else { failed++; console.error(`  FAIL [${currentTest}]: ${msg}: ${JSON.stringify(str)} does not match ${pattern}`); }
+}
+
+// ── Mock GDB Stub Server ────────────────────────────────────────
+
+function checksum(data) {
+  let sum = 0;
+  for (let i = 0; i < data.length; i++) sum += data.charCodeAt(i);
+  return (sum & 0xFF).toString(16).padStart(2, '0');
+}
+
+function makePacket(data) {
+  return `$${data}#${checksum(data)}`;
+}
+
+function createMockServer(responses) {
+  const received = [];
+  const server = createServer((socket) => {
+    let buf = '';
+    socket.on('data', (data) => {
+      buf += data.toString('binary');
+      while (buf.length > 0) {
+        if (buf.charCodeAt(0) === 0x03) {
+          buf = buf.slice(1);
+          received.push('<interrupt>');
+          socket.write(makePacket('T02thread:01;'), 'binary');
+          continue;
+        }
+        if (buf[0] === '+' || buf[0] === '-') { buf = buf.slice(1); continue; }
+        const dollar = buf.indexOf('$');
+        if (dollar === -1) { buf = ''; break; }
+        if (dollar > 0) buf = buf.slice(dollar);
+        const hash = buf.indexOf('#');
+        if (hash === -1 || hash + 2 >= buf.length) break;
+        const payload = buf.slice(1, hash);
+        buf = buf.slice(hash + 3);
+        received.push(payload);
+        socket.write('+', 'binary');
+        let reply = '';
+        for (const [prefix, resp] of responses) {
+          if (payload === prefix || payload.startsWith(prefix)) {
+            reply = resp;
+            break;
+          }
+        }
+        socket.write(makePacket(reply), 'binary');
+      }
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ port: server.address().port, close: () => server.close(), received });
+    });
+  });
+}
+
+const HANDSHAKE = new Map([
+  ['qSupported', 'PacketSize=4000;swbreak+;hwbreak+'],
+  ['QStartNoAckMode', 'OK'],
+  ['?', 'S05'],
+]);
+
+function mockWithHandshake(extra) {
+  const map = new Map(HANDSHAKE);
+  for (const [k, v] of extra) map.set(k, v);
+  return createMockServer(map);
+}
+
+// ── Address Parsing Tests ───────────────────────────────────────
+
+function testParseAddr() {
+  currentTest = 'parseAddr';
+
+  // Hex with prefix
+  assertEq(parseAddr('0x1234'), 0x1234, '0x prefix');
+  assertEq(parseAddr('0XFF'), 0xFF, '0X prefix');
+  assertEq(parseAddr('$D000'), 0xD000, '$ prefix');
+
+  // Decimal
+  assertEq(parseAddr('#255'), 255, '# decimal');
+  assertEq(parseAddr('#0'), 0, '# zero');
+
+  // Bare hex
+  assertEq(parseAddr('FF'), 0xFF, 'bare hex FF');
+  assertEq(parseAddr('d000'), 0xD000, 'bare hex d000');
+  assertEq(parseAddr('0400'), 0x0400, 'bare hex 0400');
+
+  // Labels (with symbol map)
+  const syms = new Map([['start', 0xE000], ['loop', 0xE010]]);
+  assertEq(parseAddr('start', syms), 0xE000, 'label lookup');
+  assertEq(parseAddr('loop', syms), 0xE010, 'label lookup');
+  assertEq(parseAddr('$D000', syms), 0xD000, 'hex takes priority over label miss');
+
+  // Non-hex chars → NaN (label miss)
+  assert(isNaN(parseAddr('foobar')), 'non-hex string returns NaN');
+  assert(isNaN(parseAddr('my_label')), 'underscore returns NaN');
+
+  // Edge cases
+  assert(isNaN(parseAddr(null)), 'null returns NaN');
+  assert(isNaN(parseAddr(undefined)), 'undefined returns NaN');
+  assert(isNaN(parseAddr('')), 'empty returns NaN');
+}
+
+// ── Symbol Loading Tests ────────────────────────────────────────
+
+function testLoadSymbols() {
+  currentTest = 'loadSymbols';
+
+  const tmpFile = join(tmpdir(), `n8mcp_test_sym_${Date.now()}.sym`);
+  writeFileSync(tmpFile, [
+    'al 00D000 .start',
+    'al 00D010 .main_loop',
+    'al 00D100 .tty_write',
+    'al 000200 .buffer',
+    '// comment line',
+    '',
+    'al 00D000 .entry',  // duplicate address
+  ].join('\n'));
+
+  const syms = new Map();
+  const labels = new Map();
+  const count = loadSymbols(tmpFile, syms, labels);
+
+  assertEq(count, 5, 'symbol count (5 al lines)');
+  assertEq(syms.get('start'), 0xD000, 'start symbol');
+  assertEq(syms.get('main_loop'), 0xD010, 'main_loop');
+  assertEq(syms.get('tty_write'), 0xD100, 'tty_write');
+  assertEq(syms.get('buffer'), 0x0200, 'buffer');
+  assertEq(syms.get('entry'), 0xD000, 'entry (dup addr)');
+
+  // addrLabels: D000 should have both 'start' and 'entry'
+  const d000Labels = labels.get(0xD000);
+  assert(d000Labels && d000Labels.includes('start'), 'D000 has start');
+  assert(d000Labels && d000Labels.includes('entry'), 'D000 has entry');
+
+  unlinkSync(tmpFile);
+}
+
+// ── Formatting Tests ────────────────────────────────────────────
+
+function testHex8() {
+  currentTest = 'hex8';
+  assertEq(hex8(0), '00', 'zero');
+  assertEq(hex8(0xFF), 'ff', '0xFF');
+  assertEq(hex8(0x42), '42', '0x42');
+}
+
+function testHex16() {
+  currentTest = 'hex16';
+  assertEq(hex16(0), '0000', 'zero');
+  assertEq(hex16(0xD000), 'd000', '0xD000');
+  assertEq(hex16(0xFFFF), 'ffff', '0xFFFF');
+}
+
+function testHexdump() {
+  currentTest = 'hexdump';
+  const buf = Buffer.from([0x48, 0x65, 0x6c, 0x6c, 0x6f]);
+  const result = hexdump(buf, 0x0200);
+  assert(result.includes('0200:'), 'has address');
+  assert(result.includes('48 65 6c 6c 6f'), 'has hex bytes');
+  assert(result.includes('Hello'), 'has ASCII');
+
+  // Multi-line (> 16 bytes)
+  const buf32 = Buffer.alloc(32, 0x41);
+  const result32 = hexdump(buf32, 0x1000);
+  assert(result32.includes('1000:'), 'first line addr');
+  assert(result32.includes('1010:'), 'second line addr');
+}
+
+function testFmtRegs() {
+  currentTest = 'fmtRegs';
+  const r = { a: 0x42, x: 0x0A, y: 0x14, s: 0xFF, p: 0x30, pc: 0xD000 };
+  const result = fmtRegs(r);
+  assert(result.includes('A:42'), 'A register');
+  assert(result.includes('X:0a'), 'X register');
+  assert(result.includes('PC:d000'), 'PC register');
+  assert(result.includes('Flags:'), 'has flags');
+
+  // With labels
+  const labels = new Map([[0xD000, ['start', 'entry']]]);
+  const result2 = fmtRegs(r, labels);
+  assert(result2.includes('@ start, entry'), 'label annotation');
+}
+
+function testFmtStop() {
+  currentTest = 'fmtStop';
+  assertEq(fmtStop('T05thread:01;'), 'breakpoint hit', 'breakpoint');
+  assertEq(fmtStop('T05watch:1234;'), 'watchpoint (write) hit', 'write watchpoint');
+  assertEq(fmtStop('T05rwatch:1234;'), 'watchpoint (read) hit', 'read watchpoint');
+  assertEq(fmtStop('T05awatch:1234;'), 'watchpoint (access) hit', 'access watchpoint');
+  assertEq(fmtStop('T02thread:01;'), 'stopped signal 2', 'signal 2');
+  assertEq(fmtStop(null), 'no reply', 'null');
+}
+
+// ── Charmap Tests ───────────────────────────────────────────────
+
+function testCharmap() {
+  currentTest = 'charmap';
+  assertEq(N8_CHARMAP.length, 256, '256 entries');
+  assertEq(N8_CHARMAP[0x00], ' ', 'null → space');
+  assertEq(N8_CHARMAP[0x20], ' ', 'space');
+  assertEq(N8_CHARMAP[0x41], 'A', 'A');
+  assertEq(N8_CHARMAP[0x61], 'a', 'a');
+  assertEq(N8_CHARMAP[0x7E], '~', 'tilde');
+  assertEq(N8_CHARMAP[0x80], '\u2588', 'full block');
+}
+
+// ── Keyboard Tests ──────────────────────────────────────────────
+
+function testCharToKeycode() {
+  currentTest = 'charToKeycode';
+  const a = charToKeycode('A');
+  assertEq(a.keycode, 0x41, 'A keycode');
+  assertEq(a.modifiers, 0x00, 'A no modifiers');
+
+  const space = charToKeycode(' ');
+  assertEq(space.keycode, 0x20, 'space keycode');
+
+  assertEq(charToKeycode('\x01'), null, 'control char returns null');
+}
+
+function testParseKeyInput() {
+  currentTest = 'parseKeyInput';
+
+  // Simple text
+  let r = parseKeyInput('hi');
+  assertEq(r.error, null, 'no error');
+  assertEq(r.keys.length, 2, '2 keys');
+  assertEq(r.keys[0].keycode, 0x68, 'h');
+  assertEq(r.keys[1].keycode, 0x69, 'i');
+
+  // Named key
+  r = parseKeyInput('[enter]');
+  assertEq(r.error, null, 'no error');
+  assertEq(r.keys.length, 1, '1 key');
+  assertEq(r.keys[0].keycode, 0x0D, 'enter');
+
+  // Mixed text and keys
+  r = parseKeyInput('go[enter]');
+  assertEq(r.keys.length, 3, '3 keys');
+  assertEq(r.keys[2].keycode, 0x0D, 'trailing enter');
+
+  // Hex key
+  r = parseKeyInput('[0x41]');
+  assertEq(r.keys.length, 1, '1 key');
+  assertEq(r.keys[0].keycode, 0x41, 'hex 0x41');
+
+  // Backslash-n
+  r = parseKeyInput('a\\nb');
+  assertEq(r.keys.length, 3, '3 keys');
+  assertEq(r.keys[1].keycode, 0x0D, 'backslash-n → enter');
+
+  // Modifier flags
+  r = parseKeyInput('a', 0x04);
+  assertEq(r.keys[0].modifiers, 0x04, 'shift modifier');
+
+  // Unknown key
+  r = parseKeyInput('[bogus]');
+  assert(r.error !== null, 'unknown key error');
+
+  // Empty
+  r = parseKeyInput('');
+  assertEq(r.keys.length, 0, 'empty input');
+}
+
+function testNamedKeys() {
+  currentTest = 'namedKeys';
+  assertEq(NAMED_KEYS.enter, 0x0D, 'enter');
+  assertEq(NAMED_KEYS.esc, 0x1B, 'esc');
+  assertEq(NAMED_KEYS.tab, 0x09, 'tab');
+  assertEq(NAMED_KEYS.backspace, 0x08, 'backspace');
+  assertEq(NAMED_KEYS.up, 0x01, 'up');
+  assertEq(NAMED_KEYS.f1, 0x80, 'f1');
+  assertEq(NAMED_KEYS.f12, 0x8B, 'f12');
+}
+
+// ── Mock RSP Integration Tests ──────────────────────────────────
+// These test the tool handler logic via mock RSP servers
+
+async function testMcpRegs() {
+  currentTest = 'mcp:n8_regs';
+  // A=42, X=0a, Y=14, S=ff, PC=d000(LE: 00d0), P=30
+  const mock = await mockWithHandshake(new Map([
+    ['g', '420a14ff00d030'],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+  const r = await client.readRegisters();
+  const text = fmtRegs(r);
+
+  assert(text.includes('A:42'), 'regs output has A');
+  assert(text.includes('PC:d000'), 'regs output has PC');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMcpReadMemory() {
+  currentTest = 'mcp:n8_read_memory';
+  const mock = await mockWithHandshake(new Map([
+    ['m', '48656c6c6f576f726c6421'],  // HelloWorld!
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+  const buf = await client.readMemory(0x0200, 11);
+  const text = hexdump(buf, 0x0200);
+
+  assert(text.includes('0200:'), 'hexdump has address');
+  assert(text.includes('HelloWorld!'), 'hexdump has ASCII');
+  assert(mock.received.includes('m200,b'), 'sent correct m command');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMcpWriteMemory() {
+  currentTest = 'mcp:n8_write_memory';
+  const mock = await mockWithHandshake(new Map([
+    ['M', 'OK'],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  const data = Buffer.from('a9428d0002', 'hex');
+  await client.writeMemory(0x0400, data);
+
+  assert(mock.received.some(r => r.startsWith('M400,5:a9428d0002')), 'write command sent');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMcpWriteReg() {
+  currentTest = 'mcp:n8_write_reg';
+  const mock = await mockWithHandshake(new Map([
+    ['P', 'OK'],
+    ['g', '420a14ff00d030'],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  // Write A register
+  await client.writeRegister(0, 0x42);
+  assert(mock.received.some(r => r === 'P0=42'), 'wrote A');
+
+  // Write PC (16-bit LE)
+  await client.writeRegister(4, 0xD000);
+  assert(mock.received.some(r => r === 'P4=00d0'), 'wrote PC LE');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMcpStep() {
+  currentTest = 'mcp:n8_step';
+  const mock = await mockWithHandshake(new Map([
+    ['s', 'T05thread:01;'],
+    ['g', '420a14ff00d030'],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  const reply = await client.step();
+  assert(reply.startsWith('T05'), 'step returns SIGTRAP');
+
+  const r = await client.readRegisters();
+  const text = `${fmtStop(reply)}\n${fmtRegs(r)}`;
+  assert(text.includes('breakpoint hit'), 'formatted stop');
+  assert(text.includes('PC:d000'), 'formatted regs');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMcpRun() {
+  currentTest = 'mcp:n8_run';
+  const mock = await mockWithHandshake(new Map([
+    ['c', 'T05thread:01;'],
+    ['g', '420a14ff10e030'],  // PC=e010
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  const reply = await client.continue(5000);
+  assert(reply.startsWith('T05'), 'run returns stop reply');
+
+  const r = await client.readRegisters();
+  assertEq(r.pc, 0xE010, 'PC after run');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMcpHalt() {
+  currentTest = 'mcp:n8_halt';
+  // Server that only responds to interrupt, not 'c'
+  const received = [];
+  const server = createServer((socket) => {
+    let buf = '';
+    socket.on('data', (data) => {
+      buf += data.toString('binary');
+      while (buf.length > 0) {
+        if (buf.charCodeAt(0) === 0x03) {
+          buf = buf.slice(1);
+          received.push('<interrupt>');
+          socket.write(makePacket('T02thread:01;'), 'binary');
+          continue;
+        }
+        if (buf[0] === '+' || buf[0] === '-') { buf = buf.slice(1); continue; }
+        const dollar = buf.indexOf('$');
+        if (dollar === -1) { buf = ''; break; }
+        if (dollar > 0) buf = buf.slice(dollar);
+        const hash = buf.indexOf('#');
+        if (hash === -1 || hash + 2 >= buf.length) break;
+        const payload = buf.slice(1, hash);
+        buf = buf.slice(hash + 3);
+        received.push(payload);
+        socket.write('+', 'binary');
+        if (payload.startsWith('qSupported')) socket.write(makePacket('PacketSize=4000'), 'binary');
+        else if (payload === 'QStartNoAckMode') socket.write(makePacket('OK'), 'binary');
+        else if (payload === '?') socket.write(makePacket('S05'), 'binary');
+        else if (payload === 'g') socket.write(makePacket('420a14ff00d030'), 'binary');
+        // 'c' command: don't respond
+      }
+    });
+  });
+
+  const { port } = await new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => resolve({ port: server.address().port }));
+  });
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', port);
+  client.continueAsync();
+  await new Promise(r => setTimeout(r, 100));
+
+  const reply = await client.pause();
+  assert(reply.startsWith('T02') || reply.startsWith('S'), 'halt returns stop reply');
+  assert(received.includes('<interrupt>'), 'sent interrupt byte');
+
+  const r = await client.readRegisters();
+  assert(r.pc !== undefined, 'can read regs after halt');
+
+  client.disconnect();
+  server.close();
+}
+
+async function testMcpReset() {
+  currentTest = 'mcp:n8_reset';
+  const mock = await mockWithHandshake(new Map([
+    ['mfffc,2', '00e0'],  // reset vector → $E000 (LE)
+    ['P', 'OK'],
+    ['g', '000000ff00e030'],  // PC=e000 after reset
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  // Read reset vector
+  const vec = await client.readMemory(0xFFFC, 2);
+  const resetAddr = vec[0] | (vec[1] << 8);
+  assertEq(resetAddr, 0xE000, 'reset vector');
+
+  // Set PC
+  await client.writeRegister(4, resetAddr);
+  assert(mock.received.some(r => r === 'P4=00e0'), 'set PC to reset vector');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMcpBreakpoints() {
+  currentTest = 'mcp:n8_breakpoints';
+  const mock = await mockWithHandshake(new Map([
+    ['Z0', 'OK'],
+    ['z0', 'OK'],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  await client.setBreakpoint(0xD000);
+  assert(mock.received.some(r => r === 'Z0,d000,1'), 'set BP');
+
+  await client.clearBreakpoint(0xD000);
+  assert(mock.received.some(r => r === 'z0,d000,1'), 'clear BP');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMcpClearAllBp() {
+  currentTest = 'mcp:n8_clear_all_bp';
+  const mock = await mockWithHandshake(new Map([
+    ['qRcmd', 'OK'],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  const reply = await client.monitorCommand('clear-bp');
+  assertEq(reply, 'OK', 'clear-bp OK');
+
+  // Verify the hex-encoded command was sent
+  const clearBpHex = Buffer.from('clear-bp', 'utf8').toString('hex');
+  assert(mock.received.some(r => r === `qRcmd,${clearBpHex}`), 'sent qRcmd clear-bp');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMcpKbdInject() {
+  currentTest = 'mcp:n8_kbd_inject';
+  const mock = await mockWithHandshake(new Map([
+    ['qRcmd', 'OK'],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  // Inject 'A' (keycode 0x41, modifiers 0x00)
+  const { keys } = parseKeyInput('A');
+  assertEq(keys.length, 1, '1 key');
+  assertEq(keys[0].keycode, 0x41, 'A keycode');
+
+  const reply = await client.monitorCommand(`kbd ${hex8(keys[0].keycode)} ${hex8(keys[0].modifiers)}`);
+  assertEq(reply, 'OK', 'kbd inject OK');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMcpConsoleText() {
+  currentTest = 'mcp:n8_console_text';
+
+  // Video regs (12 bytes): mode=0, width=40(0x28), height=2, stride=40(0x28), oper=0, cursor_style=1, col=5, row=1, vsync=0, ctrl=0, data=0, status=0
+  const videoRegsHex = '002802280001050100000000';
+  // Framebuffer: 2 rows of 40 chars, "Hello" + spaces, then empty row
+  const row1 = '48656c6c6f' + '00'.repeat(35);
+  const row2 = '00'.repeat(40);
+
+  // The mock matches command prefixes, so 'md840' matches readMemory(0xD840,...)
+  // and 'mc000' matches readMemory(0xC000,...)
+  const mock = await mockWithHandshake(new Map([
+    ['md840', videoRegsHex],
+    ['mc000', row1 + row2],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  const regs = await client.readMemory(0xD840, 12);
+  const width = regs[1];
+  const height = regs[2];
+  const stride = regs[3];
+
+  assertEq(width, 0x28, 'video width');
+  assertEq(height, 2, 'video height');
+  assertEq(stride, 0x28, 'video stride');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMcpConsoleVideo() {
+  currentTest = 'mcp:n8_console_video';
+  // PNG magic bytes in hex
+  const pngHex = '89504e470d0a1a0a' + '00'.repeat(16);
+
+  const mock = await mockWithHandshake(new Map([
+    ['qXfer:n8screen:read', `l${pngHex}`],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  const hexData = await client.readXfer('n8screen');
+  const png = Buffer.from(hexData, 'hex');
+
+  // Verify PNG magic
+  assertEq(png[0], 0x89, 'PNG byte 0');
+  assertEq(png[1], 0x50, 'PNG byte 1 (P)');
+  assertEq(png[2], 0x4E, 'PNG byte 2 (N)');
+  assertEq(png[3], 0x47, 'PNG byte 3 (G)');
+
+  // Save and verify
+  const tmpPath = join(tmpdir(), `n8mcp_test_screenshot_${Date.now()}.png`);
+  writeFileSync(tmpPath, png);
+  assert(existsSync(tmpPath), 'screenshot file created');
+  unlinkSync(tmpPath);
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMcpGoto() {
+  currentTest = 'mcp:n8_goto';
+  const mock = await mockWithHandshake(new Map([
+    ['P', 'OK'],
+    ['c', 'T05thread:01;'],
+    ['g', '000000ff10e030'],  // PC=e010
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  // Set PC to E000
+  await client.writeRegister(4, 0xE000);
+  assert(mock.received.some(r => r === 'P4=00e0'), 'set PC for goto');
+
+  // Continue
+  const reply = await client.continue(5000);
+  assert(reply.startsWith('T05'), 'goto stop reply');
+
+  const r = await client.readRegisters();
+  assertEq(r.pc, 0xE010, 'PC after goto');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testAutoResume() {
+  currentTest = 'mcp:auto_resume';
+  // Connect to a server that reports T00 (was running)
+  const mock = await createMockServer(new Map([
+    ['qSupported', 'PacketSize=4000;swbreak+;hwbreak+'],
+    ['QStartNoAckMode', 'OK'],
+    ['?', 'T00thread:01;'],  // T00 = was running
+    ['g', '420a14ff00d030'],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  assert(client.wasRunning, 'wasRunning should be true for T00');
+
+  // Read regs (should work while halted for inspection)
+  const r = await client.readRegisters();
+  assertEq(r.a, 0x42, 'can read regs');
+
+  // In the real MCP, withAutoResume would call continueAsync() here
+  // We just verify the flag
+  assert(client.wasRunning, 'wasRunning still true');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testAutoResumeNotRunning() {
+  currentTest = 'mcp:auto_resume_not_running';
+  const mock = await mockWithHandshake(new Map([
+    ['g', '420a14ff00d030'],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  // S05 = halted, wasRunning should be false
+  assert(!client.wasRunning, 'wasRunning should be false for S05');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testSymbolAddressResolution() {
+  currentTest = 'mcp:symbol_address_resolution';
+
+  // Load symbols and verify they work with parseAddr
+  const tmpFile = join(tmpdir(), `n8mcp_test_resolve_${Date.now()}.sym`);
+  writeFileSync(tmpFile, [
+    'al 00E000 .start',
+    'al 00E010 .main_loop',
+    'al 000400 .user_program',
+  ].join('\n'));
+
+  const syms = new Map();
+  const labels = new Map();
+  loadSymbols(tmpFile, syms, labels);
+
+  // parseAddr with symbols
+  assertEq(parseAddr('start', syms), 0xE000, 'resolve start');
+  assertEq(parseAddr('main_loop', syms), 0xE010, 'resolve main_loop');
+  assertEq(parseAddr('user_program', syms), 0x0400, 'resolve user_program');
+  assertEq(parseAddr('$D000', syms), 0xD000, 'hex still works');
+  assert(isNaN(parseAddr('nonexistent', syms)), 'missing label NaN');
+
+  unlinkSync(tmpFile);
+}
+
+async function testMcpLoadBinary() {
+  currentTest = 'mcp:n8_load_binary';
+
+  // Create a temp binary
+  const tmpBin = join(tmpdir(), `n8mcp_test_bin_${Date.now()}.bin`);
+  const binData = Buffer.from([0xA9, 0x42, 0x8D, 0x00, 0x02, 0x60]);
+  writeFileSync(tmpBin, binData);
+
+  const mock = await mockWithHandshake(new Map([
+    ['M', 'OK'],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  const data = readFileSync(tmpBin);
+  await client.writeMemory(0xE000, data);
+
+  assert(mock.received.some(r => r.startsWith('Me000,6:')), 'load binary sends M command');
+
+  client.disconnect();
+  mock.close();
+  unlinkSync(tmpBin);
+}
+
+async function testMonitorCommand() {
+  currentTest = 'mcp:monitor_command';
+  const mock = await mockWithHandshake(new Map([
+    ['qRcmd', 'OK'],
+  ]));
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', mock.port);
+
+  // Test kbd inject via monitor command
+  const reply = await client.monitorCommand('kbd 41 00');
+  assertEq(reply, 'OK', 'monitor command OK');
+
+  const kbdHex = Buffer.from('kbd 41 00', 'utf8').toString('hex');
+  assert(mock.received.some(r => r === `qRcmd,${kbdHex}`), 'sent correct qRcmd hex');
+
+  client.disconnect();
+  mock.close();
+}
+
+async function testMultiStepStop() {
+  currentTest = 'mcp:multi_step_stop';
+  // Server that returns T04 (SIGILL/jam) on second step
+  let stepCount = 0;
+  const server = createServer((socket) => {
+    let buf = '';
+    socket.on('data', (data) => {
+      buf += data.toString('binary');
+      while (buf.length > 0) {
+        if (buf[0] === '+' || buf[0] === '-') { buf = buf.slice(1); continue; }
+        const dollar = buf.indexOf('$');
+        if (dollar === -1) { buf = ''; break; }
+        if (dollar > 0) buf = buf.slice(dollar);
+        const hash = buf.indexOf('#');
+        if (hash === -1 || hash + 2 >= buf.length) break;
+        const payload = buf.slice(1, hash);
+        buf = buf.slice(hash + 3);
+        socket.write('+', 'binary');
+        if (payload.startsWith('qSupported')) socket.write(makePacket('PacketSize=4000'), 'binary');
+        else if (payload === 'QStartNoAckMode') socket.write(makePacket('OK'), 'binary');
+        else if (payload === '?') socket.write(makePacket('S05'), 'binary');
+        else if (payload === 's') {
+          stepCount++;
+          socket.write(makePacket(stepCount < 3 ? 'T05thread:01;' : 'T04thread:01;'), 'binary');
+        }
+        else if (payload === 'g') socket.write(makePacket('420a14ff00d030'), 'binary');
+      }
+    });
+  });
+
+  const { port } = await new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => resolve({ port: server.address().port }));
+  });
+
+  const client = new RspClient();
+  await client.connect('127.0.0.1', port);
+
+  // Step 5 times, should stop at step 3 (T04)
+  let lastReply;
+  let stepsCompleted = 0;
+  for (let i = 0; i < 5; i++) {
+    lastReply = await client.step();
+    stepsCompleted++;
+    if (!lastReply.startsWith('T05') && !lastReply.startsWith('S05')) break;
+  }
+
+  assertEq(stepsCompleted, 3, 'stopped after 3 steps');
+  assert(lastReply.startsWith('T04'), 'got SIGILL');
+  assertEq(fmtStop(lastReply), 'stopped signal 4', 'formatted as signal 4');
+
+  client.disconnect();
+  server.close();
+}
+
+// ── Run all ─────────────────────────────────────────────────────
+
+async function main() {
+  console.log('n8mcp tests\n');
+
+  // Sync tests (shared modules)
+  console.log('-- shared/address --');
+  testParseAddr();
+
+  console.log('-- shared/symbols --');
+  testLoadSymbols();
+
+  console.log('-- shared/format --');
+  testHex8();
+  testHex16();
+  testHexdump();
+  testFmtRegs();
+  testFmtStop();
+
+  console.log('-- shared/charmap --');
+  testCharmap();
+
+  console.log('-- shared/keyboard --');
+  testCharToKeycode();
+  testParseKeyInput();
+  testNamedKeys();
+
+  // Async tests (mock RSP)
+  console.log('-- mcp tools (mock RSP) --');
+  const asyncTests = [
+    testMcpRegs,
+    testMcpReadMemory,
+    testMcpWriteMemory,
+    testMcpWriteReg,
+    testMcpStep,
+    testMcpRun,
+    testMcpHalt,
+    testMcpReset,
+    testMcpBreakpoints,
+    testMcpClearAllBp,
+    testMcpKbdInject,
+    testMcpConsoleText,
+    testMcpConsoleVideo,
+    testMcpGoto,
+    testAutoResume,
+    testAutoResumeNotRunning,
+    testSymbolAddressResolution,
+    testMcpLoadBinary,
+    testMonitorCommand,
+    testMultiStepStop,
+  ];
+
+  for (const test of asyncTests) {
+    try {
+      await test();
+    } catch (err) {
+      failed++;
+      console.error(`  FAIL (exception) [${test.name}]: ${err.message}`);
+      if (process.env.N8GDB_DEBUG === '1') console.error(err.stack);
+    }
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main();

--- a/bin/shared/address.mjs
+++ b/bin/shared/address.mjs
@@ -1,0 +1,20 @@
+/**
+ * Address parsing for N8machine tools.
+ * Supports hex (0x, $, bare), decimal (#), and label lookup.
+ */
+
+/**
+ * Parse an address string to a number.
+ * @param {string} str - Address string
+ * @param {Map<string, number>} [symbols] - Optional symbol table for label lookup
+ * @returns {number} Parsed address, or NaN if invalid
+ */
+export function parseAddr(str, symbols) {
+  if (!str) return NaN;
+  if (symbols?.has(str)) return symbols.get(str);
+  if (str.startsWith('#')) return parseInt(str.slice(1), 10);
+  if (str.startsWith('0x') || str.startsWith('0X')) return parseInt(str.slice(2), 16);
+  if (str.startsWith('$')) return parseInt(str.slice(1), 16);
+  if (/[g-zG-Z_]/.test(str)) return NaN;
+  return parseInt(str, 16);
+}

--- a/bin/shared/charmap.mjs
+++ b/bin/shared/charmap.mjs
@@ -1,0 +1,56 @@
+/**
+ * N8 character map — maps byte values ($00-$FF) to Unicode characters.
+ */
+
+// prettier-ignore
+export const N8_CHARMAP = [
+  // $00-$0F
+  ' ',     '\u263A', '\u25CF', '\u2665', '\u2666', '\u2663', '\u2660', '\u2026',
+  '\u2713', '\u2717', '\u2605', '\u00DF', '\u2190', '\u2192', '\u2191', '\u2193',
+  // $10-$1F
+  '\u21B5', '\u21D0', '\u21D2', '\u21D1', '\u21D3', '\u25B6', '\u25C0', '\u25B2',
+  '\u25BC', '\u2194', '\u2195', '\u2302', '\u266A', '\u266B', '\u00A7', '\u00B6',
+  // $20-$7E: standard ASCII
+  ...Array.from({length: 95}, (_, i) => String.fromCharCode(0x20 + i)),
+  // $7F
+  '\u2310',
+  // $80-$8F: block elements
+  '\u2588', '\u2580', '\u2584', '\u258C', '\u2590', '\u2598', '\u259D', '\u2596',
+  '\u2597', '\u259A', '\u259E', '\u259B', '\u259C', '\u2599', '\u259F', '\u2591',
+  // $90-$9F: shading, thirds, diagonals
+  '\u2592', '\u2593', '\u2594', '\u2581', '\u258F', '\u2595', '\u2586', '\u2582',
+  '\u25E2', '\u25E3', '\u25E4', '\u25E5', '\u2571', '\u2572', '\u2573', '\u25AC',
+  // $A0-$AA: single-line box drawing
+  '\u2500', '\u2502', '\u250C', '\u2510', '\u2514', '\u2518', '\u251C', '\u2524',
+  '\u252C', '\u2534', '\u253C',
+  // $AB-$B5: heavy-line box drawing
+  '\u2501', '\u2503', '\u250F', '\u2513', '\u2517', '\u251B', '\u2523', '\u252B',
+  '\u2533', '\u253B', '\u254B',
+  // $B6-$B9: rounded corners
+  '\u256D', '\u256E', '\u2570', '\u256F',
+  // $BA-$BD: dashed
+  '\u254C', '\u254E', '\u254D', '\u254F',
+  // $BE-$BF: inverted punctuation
+  '\u00A1', '\u00BF',
+  // $C0-$CF: international
+  '\u00C0', '\u00C1', '\u00C4', '\u00C7', '\u00C9', '\u00D1', '\u00D6', '\u00DC',
+  '\u00E0', '\u00E1', '\u00E4', '\u00E7', '\u00E9', '\u00F1', '\u00F6', '\u00FC',
+  // $D0-$D9: geometric
+  '\u25CB', '\u25CE', '\u25A1', '\u25A0', '\u25B3', '\u25B7', '\u25BD', '\u25C1',
+  '\u25C7', '\u2606',
+  // $DA-$DF: dice
+  '\u2680', '\u2681', '\u2682', '\u2683', '\u2684', '\u2685',
+  // $E0-$EF: math/greek
+  '\u00B1', '\u00D7', '\u00F7', '\u2260', '\u2264', '\u2265', '\u2248', '\u00B0',
+  '\u221E', '\u221A', '\u03C0', '\u03A3', '\u03C3', '\u03BC', '\u03A9', '\u03B4',
+  // $F0-$F4: currency
+  '\u00A2', '\u00A3', '\u00A5', '\u20AC', '\u00A4',
+  // $F5-$F9: electronics
+  '\u23FB', '\u23DA', '\u26A1', '\u2316', '\u2318',
+  // $FA-$FB: copyright/registered
+  '\u00A9', '\u00AE',
+  // $FC-$FD: guillemets
+  '\u00AB', '\u00BB',
+  // $FE-$FF: N8 two-thirds blocks (closest Unicode approx)
+  '\u258A', '\u258E',
+];

--- a/bin/shared/console.mjs
+++ b/bin/shared/console.mjs
@@ -1,0 +1,49 @@
+/**
+ * Console text reading for N8machine video framebuffer.
+ * Shared by n8mcp and n8gdb.
+ */
+
+import { N8_CHARMAP } from './charmap.mjs';
+import { hex8 } from './format.mjs';
+
+/**
+ * Read video registers and framebuffer, return formatted Unicode text.
+ * @param {object} rsp - RspClient instance with readMemory()
+ * @returns {Promise<string>}
+ */
+export async function readConsoleText(rsp) {
+  const regs = await rsp.readMemory(0xD840, 12);
+  const mode   = regs[0];
+  const width  = regs[1];
+  const height = regs[2];
+  const stride = regs[3];
+  const curStyle = regs[5];
+  const curCol   = regs[6];
+  const curRow   = regs[7];
+
+  const fbSize = stride * height;
+  if (fbSize === 0 || fbSize > 0x1000) {
+    throw new Error(`Invalid video dimensions: ${width}x${height} stride=${stride}`);
+  }
+
+  const fb = await rsp.readMemory(0xC000, fbSize);
+
+  const modeStr = mode === 0 ? 'Text Default' : mode === 1 ? 'Text Custom' : `0x${hex8(mode)}`;
+  const curModeStr = (curStyle & 0x03) === 0 ? 'off' : (curStyle & 0x03) === 1 ? 'steady' : 'flash';
+  const curShapeStr = (curStyle & 0x0C) === 0x04 ? 'block' : 'underline';
+
+  const lines = [];
+  lines.push(`Mode: ${modeStr}  Size: ${width}\u00D7${height}  Stride: ${stride}  Cursor: (${curCol},${curRow}) ${curModeStr} ${curShapeStr}`);
+  lines.push('\u2500'.repeat(width));
+
+  for (let row = 0; row < height; row++) {
+    let line = '';
+    for (let col = 0; col < width; col++) {
+      const byte = fb[row * stride + col];
+      line += N8_CHARMAP[byte] || '?';
+    }
+    lines.push(line);
+  }
+  lines.push('\u2500'.repeat(width));
+  return lines.join('\n');
+}

--- a/bin/shared/format.mjs
+++ b/bin/shared/format.mjs
@@ -1,0 +1,60 @@
+/**
+ * Formatting utilities for N8machine tools.
+ */
+
+export function hex8(v) { return v.toString(16).padStart(2, '0'); }
+export function hex16(v) { return v.toString(16).padStart(4, '0'); }
+
+function bit(v, b) { return (v >> b) & 1; }
+
+/**
+ * Format a hex dump of a buffer.
+ * @param {Buffer|Uint8Array} buf
+ * @param {number} baseAddr
+ * @returns {string}
+ */
+export function hexdump(buf, baseAddr) {
+  const lines = [];
+  for (let off = 0; off < buf.length; off += 16) {
+    const slice = buf.subarray(off, Math.min(off + 16, buf.length));
+    const hex = Array.from(slice).map(b => b.toString(16).padStart(2, '0')).join(' ');
+    const ascii = Array.from(slice).map(b => (b >= 0x20 && b <= 0x7e) ? String.fromCharCode(b) : '.').join('');
+    const addr = (baseAddr + off).toString(16).padStart(4, '0');
+    lines.push(`${addr}: ${hex.padEnd(48)} ${ascii}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Format CPU registers.
+ * @param {{ a: number, x: number, y: number, s: number, p: number, pc: number }} r
+ * @param {Map<number, string[]>} [addrLabels] - Optional address-to-label map
+ * @returns {string}
+ */
+export function fmtRegs(r, addrLabels) {
+  const lines = [];
+  lines.push(`A:${hex8(r.a)}  X:${hex8(r.x)}  Y:${hex8(r.y)}  S:${hex8(r.s)}  P:${hex8(r.p)}  PC:${hex16(r.pc)}`);
+  const p = r.p;
+  const flags = `N${bit(p,7)} V${bit(p,6)} -${bit(p,5)} B${bit(p,4)} D${bit(p,3)} I${bit(p,2)} Z${bit(p,1)} C${bit(p,0)}`;
+  lines.push(`Flags: ${flags}`);
+  if (addrLabels?.has(r.pc)) lines.push(`  @ ${addrLabels.get(r.pc).join(', ')}`);
+  return lines.join('\n');
+}
+
+/**
+ * Format a stop reply from GDB RSP.
+ * @param {string} reply
+ * @returns {string}
+ */
+export function fmtStop(reply) {
+  if (!reply) return 'no reply';
+  if (reply.startsWith('T05')) {
+    if (reply.includes('awatch:')) return `watchpoint (access) hit`;
+    if (reply.includes('rwatch:')) return `watchpoint (read) hit`;
+    if (reply.includes('watch:')) return `watchpoint (write) hit`;
+    return `breakpoint hit`;
+  }
+  if (reply.startsWith('T')) return `stopped signal ${parseInt(reply.slice(1, 3), 16)}`;
+  if (reply.startsWith('S')) return `stopped signal ${parseInt(reply.slice(1, 3), 16)}`;
+  return reply;
+}

--- a/bin/shared/keyboard.mjs
+++ b/bin/shared/keyboard.mjs
@@ -1,0 +1,87 @@
+/**
+ * N8 keyboard constants and key injection parsing.
+ */
+
+export const NAMED_KEYS = {
+  enter: 0x0D, return: 0x0D, cr: 0x0D,
+  backspace: 0x08, bs: 0x08,
+  tab: 0x09,
+  esc: 0x1B, escape: 0x1B,
+  delete: 0x0F, del: 0x0F,
+  space: 0x20,
+  up: 0x01, down: 0x02, left: 0x03, right: 0x04,
+  home: 0x05, end: 0x06, pageup: 0x0A, pagedown: 0x0B, insert: 0x0E,
+  printscreen: 0x10, pause: 0x11,
+  f1: 0x80, f2: 0x81, f3: 0x82, f4: 0x83, f5: 0x84, f6: 0x85,
+  f7: 0x86, f8: 0x87, f9: 0x88, f10: 0x89, f11: 0x8A, f12: 0x8B,
+};
+
+/**
+ * Convert a printable ASCII character to an N8 keycode.
+ * @param {string} ch - Single character
+ * @returns {{ keycode: number, modifiers: number }|null}
+ */
+export function charToKeycode(ch) {
+  const code = ch.charCodeAt(0);
+  if (code >= 0x20 && code <= 0x7E) {
+    return { keycode: code, modifiers: 0x00 };
+  }
+  return null;
+}
+
+/**
+ * Parse an inline keyboard injection string into key events.
+ * Syntax: bare text + [named_key] or [0xNN] sequences.
+ * Example: "go north[enter]" → [{keycode: 0x67, mod: 0}, ..., {keycode: 0x0D, mod: 0}]
+ *
+ * @param {string} input - Inline key string
+ * @param {number} [extraMod=0] - Extra modifier flags to OR into each key
+ * @param {function} [parseAddr] - Address parser for [0xNN] syntax
+ * @returns {{ keys: Array<{keycode: number, modifiers: number}>, error: string|null }}
+ */
+export function parseKeyInput(input, extraMod = 0, parseAddr) {
+  const keys = [];
+  let i = 0;
+  while (i < input.length) {
+    if (input[i] === '\\' && i + 1 < input.length && input[i + 1] === 'n') {
+      keys.push({ keycode: 0x0D, modifiers: extraMod });
+      i += 2;
+    } else if (input[i] === '[') {
+      const close = input.indexOf(']', i + 1);
+      if (close === -1) {
+        const kc = charToKeycode(input[i]);
+        if (!kc) return { keys: [], error: `Cannot map character: ${input[i]}` };
+        keys.push({ keycode: kc.keycode, modifiers: kc.modifiers | extraMod });
+        i++;
+        continue;
+      }
+      const tag = input.slice(i + 1, close);
+      const tagLower = tag.toLowerCase();
+      if (tagLower in NAMED_KEYS) {
+        keys.push({ keycode: NAMED_KEYS[tagLower], modifiers: extraMod });
+      } else {
+        // Only accept explicit hex: 0x, $, or all-hex digits
+        let addr = NaN;
+        if (parseAddr) {
+          addr = parseAddr(tag);
+        } else if (/^(0[xX]|\$)[0-9a-fA-F]+$/.test(tag)) {
+          addr = parseInt(tag.replace(/^(\$|0[xX])/, ''), 16);
+        } else if (/^[0-9a-fA-F]+$/.test(tag)) {
+          addr = parseInt(tag, 16);
+        }
+        if (!isNaN(addr) && addr <= 0xFF) {
+          keys.push({ keycode: addr, modifiers: extraMod });
+        } else {
+          return { keys: [], error: `Unknown key name: [${tag}]` };
+        }
+      }
+      i = close + 1;
+    } else {
+      const kc = charToKeycode(input[i]);
+      if (!kc) return { keys: [], error: `Cannot map character: ${input[i]}` };
+      keys.push({ keycode: kc.keycode, modifiers: kc.modifiers | extraMod });
+      i++;
+    }
+  }
+  return { keys, error: null };
+}

--- a/bin/shared/package.json
+++ b/bin/shared/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "n8-shared",
+  "version": "1.0.0",
+  "description": "Shared utilities for N8machine tools",
+  "type": "module"
+}

--- a/bin/shared/symbols.mjs
+++ b/bin/shared/symbols.mjs
@@ -1,0 +1,29 @@
+/**
+ * Symbol table management for cc65 .sym files.
+ */
+
+import { readFileSync } from 'fs';
+
+/**
+ * Load a cc65 .sym file into symbol/address maps.
+ * @param {string} path - Path to .sym file
+ * @param {Map<string, number>} symbols - name -> addr map to populate
+ * @param {Map<number, string[]>} addrLabels - addr -> name[] map to populate
+ * @returns {number} Number of symbols loaded
+ */
+export function loadSymbols(path, symbols, addrLabels) {
+  const content = readFileSync(path, 'utf8');
+  let count = 0;
+  for (const line of content.split(/\r?\n/)) {
+    const m = line.match(/^al\s+([0-9a-fA-F]+)\s+\.(\S+)/);
+    if (m) {
+      const addr = parseInt(m[1], 16);
+      const name = m[2];
+      symbols.set(name, addr);
+      if (!addrLabels.has(addr)) addrLabels.set(addr, []);
+      addrLabels.get(addr).push(name);
+      count++;
+    }
+  }
+  return count;
+}


### PR DESCRIPTION
## Summary
- **n8mcp** (`bin/n8mcp/`): MCP server exposing 18 tools for N8machine emulator control via GDB RSP. Wraps `rsp.mjs` client library over stdio transport for use with Claude Code and other MCP clients.
- **Shared modules** (`bin/shared/`): Extracted symbols, address parsing, charmap, keyboard, and formatting code from n8gdb into reusable modules. Both n8gdb and n8mcp import from shared.
- **n8gdb refactored** to use shared modules — no behavior changes, all 39 existing tests pass.

### MCP Tools (18)
| Category | Tools |
|----------|-------|
| Process | `n8_start`, `n8_stop`, `n8_restart` |
| CPU | `n8_regs`, `n8_write_reg`, `n8_status` |
| Memory | `n8_read_memory`, `n8_write_memory`, `n8_load_binary` |
| Symbols | `n8_load_symbols` |
| Execution | `n8_run`, `n8_step`, `n8_halt`, `n8_reset`, `n8_goto` |
| Breakpoints | `n8_set_breakpoint`, `n8_clear_breakpoint`, `n8_clear_all_breakpoints` |
| I/O | `n8_kbd_inject`, `n8_console_text`, `n8_console_video` |

### Key design decisions
- Persistent RSP connection (lazy connect, auto-reconnect)
- Auto-resume: read-only tools restore CPU running state after inspection
- Process management: can start/stop/restart the n8 emulator GUI
- Label resolution via loaded .sym files across all address-accepting tools

## Test plan
- [x] 131 new unit tests (node bin/n8mcp/test.mjs) — shared modules + mock RSP tool handlers
- [x] 39 existing n8gdb tests pass unchanged (node bin/n8gdb/test.mjs)
- [ ] Manual: configure in ~/.claude/mcp.json, connect to running n8, exercise tools
- [ ] Manual: test n8_start/n8_stop process management

Generated with Claude Code