### PR TITLE
Implement storage commands in firmware shell

### DIFF
--- a/firmware/STORAGE_PATTERNS.md
+++ b/firmware/STORAGE_PATTERNS.md
@@ -1,0 +1,326 @@
+# N8 Storage Device — Firmware Best Practices
+
+Patterns discovered while building the shell's storage commands. All code
+references are to `firmware/shell.s` unless noted. Device spec is in
+`docs/memory_map/storage.md`.
+
+## Command Construction
+
+Two approaches were tested:
+
+### Inline sends (best for fixed, no-argument commands)
+
+Write command bytes directly to DISK_DATA. Tightest code — 3 bytes per
+character (LDA imm + STA abs). Used by `cmd_pwd`:
+
+```asm
+    LDA #N8_DISK_CONTROL_CHAN
+    STA N8_DISK_CHAN        ; select control channel, clears errors
+    LDA #'P'
+    STA N8_DISK_DATA
+    LDA #'D'
+    STA N8_DISK_DATA
+    LDA #$00
+    STA N8_DISK_DATA        ; null = execute
+```
+
+Cost: 9 bytes for "PD" + 6 bytes for channel select. Total 15 bytes.
+
+### Buffer construction (best for variable-argument commands)
+
+Build command string in RAM, then send via generic `disk_send_cmd`. Used
+by `cd`, `mkdir`, `rmdir`, `rm` through the shared `build_cmd` helper:
+
+```asm
+    LDA #'C'
+    LDX #'D'
+    JSR build_cmd           ; builds "CD,<arg>" in DISK_BUF
+    JSR disk_send_cmd       ; sends bytes + null to control channel
+```
+
+Cost: 6 bytes at call site. `build_cmd` is 25 bytes, `disk_send_cmd` is
+18 bytes — shared across all callers.
+
+**Verdict**: Use inline for 0-1 callers with fixed commands. Use buffer
+for 2+ callers with variable arguments. The crossover is ~3 callers.
+
+For commands with multi-part prefixes (e.g., `"OP,R,<file>"`), inline
+buffer construction is clearer than trying to generalize `build_cmd`:
+
+```asm
+    LDX #0
+    LDA #'O'  / STA DISK_BUF,X / INX
+    LDA #'P'  / STA DISK_BUF,X / INX
+    LDA #','  / STA DISK_BUF,X / INX
+    LDA #'R'  / STA DISK_BUF,X / INX
+    LDA #','  / STA DISK_BUF,X / INX
+    ; copy arg bytes...
+```
+
+## Response Reading
+
+### Stream-to-console (best for text output)
+
+Read DISK_DATA one byte at a time, send to K_CON_PUTCHAR. Poll
+DISK_STATUS for available count, then read exactly that many bytes
+before re-polling. Convert $0A to K_CON_NEWLINE.
+
+```asm
+disk_stream_to_con:
+@poll:  LDA N8_DISK_STATUS
+        TAX
+        AND #N8_DISK_STAT_AVAIL
+        BNE @read
+        TXA
+        AND #N8_DISK_STAT_EOF
+        BNE @done
+        JMP @poll
+@read:  TAY                     ; Y = avail count
+@byte:  LDA N8_DISK_DATA
+        CMP #$0A
+        BEQ @newline
+        JSR K_CON_PUTCHAR
+        JMP @next
+@newline: JSR K_CON_NEWLINE
+@next:  DEY
+        BNE @byte
+        JMP @poll
+@done:  RTS
+```
+
+Key pattern: the inner loop reads exactly `avail` bytes before going
+back to poll. This avoids reading DISK_STATUS on every byte — saves
+cycles in the common case where multiple bytes are available.
+
+Used by: `pwd`, `cat`. 30 bytes, highly reusable.
+
+### Buffer-then-parse (best for structured data)
+
+Read entire response into RAM buffer, then walk with an index register.
+Used by `ls` where raw format must be reformatted.
+
+```asm
+disk_read_to_buf:
+        LDX #0
+@poll:  LDA N8_DISK_STATUS
+        ; ... same poll pattern ...
+@byte:  LDA N8_DISK_DATA
+        STA DISK_BUF,X
+        INX
+        BEQ @done               ; X wraps to 0 = 256 bytes = full
+        DEY / BNE @byte
+        JMP @poll
+@done:  STX ZP_DCNT
+        RTS
+```
+
+The `INX / BEQ @done` trick gives a free 256-byte overflow guard
+using the 6502's zero flag on register wrap.
+
+Buffer costs 256 bytes of RAM ($0300-$03FF) but makes parsing trivial —
+just walk with X as index. For LS format `D|F\t<name>\t<lo><hi>\n`,
+the parser skips fixed fields and loops only on the variable-length
+name. ~80 bytes of parser code.
+
+**Verdict**: Stream for pass-through text. Buffer for structured data
+that needs reformatting. Don't try to stream-parse LS format — the
+state machine complexity isn't worth the RAM savings.
+
+## Error Handling
+
+### Error string table
+
+14 error codes ($01-$0E) mapped to short human-readable strings via a
+pointer table. `disk_check_error` reads DISK_ERROR, indexes the table,
+and prints `"<cmd>: <message>"`:
+
+```asm
+disk_check_error:
+        LDA N8_DISK_ERROR
+        AND #N8_DISK_ERR_CMD
+        BEQ @no_err
+        LDA N8_DISK_DATA        ; error code
+        TAX
+        ; print command name from ZP_CMD...
+        DEX                     ; code-1 = table index
+        TXA / ASL A / TAX       ; *2 for word offset
+        LDA err_tbl,X / STA ZP_PTR
+        LDA err_tbl+1,X / STA ZP_PTR+1
+        ; print message...
+        SEC / RTS               ; C=1 = error
+@no_err: CLC / RTS              ; C=0 = ok
+```
+
+Cost: ~70 bytes code + ~190 bytes string data = 260 bytes total. Shared
+by all 8 commands. Worth it — hex error codes are hostile for
+interactive use.
+
+The carry flag convention (C=1 error, C=0 ok) is idiomatic 6502. All
+callers just `BCS` to their return path.
+
+## Channel Lifecycle
+
+### Response channels (LS, PWD)
+
+Auto-close when the last byte is consumed (EOF + buffer drained).
+After auto-close, DISK_CHAN bit 5 (Active) reads 0. No explicit
+CLOSE needed.
+
+Safe to skip close. Tested: `pwd` and `ls` work without close, and
+the channel is reclaimed for the next command.
+
+### File channels (OPEN for read/write)
+
+Must close explicitly via binary CL command. Forgetting to close
+leaks a channel slot (max 15). A second OPEN of the same file will
+fail with "already exists" ($02) if the first is still open.
+
+```asm
+disk_close_chan:
+        LDA #N8_DISK_CONTROL_CHAN
+        STA N8_DISK_CHAN
+        LDA #'C' / STA N8_DISK_DATA
+        LDA #'L' / STA N8_DISK_DATA
+        LDA #',' / STA N8_DISK_DATA
+        LDA ZP_CHAN / STA N8_DISK_DATA    ; binary channel ID byte
+        LDA #$00 / STA N8_DISK_DATA       ; null = execute
+        RTS
+```
+
+Note: CL uses binary payload — the parser knows to expect exactly
+1 byte after the comma. The channel ID byte can be $00 (channel 0)
+without triggering command execution.
+
+### Rule of thumb
+
+- Response channels: don't close, let auto-close handle it
+- File channels: always close in the same handler that opened them
+
+## Argument Parsing
+
+### No args (pwd)
+
+Trivial — just send command.
+
+### Single arg (cd, cat, mkdir, rmdir, rm)
+
+`ZP_ARG` is set by the shell's `process_line` to point past the
+command word and any separating spaces. Just check it's not empty
+(`LDA (ZP_ARG),Y / BEQ missing`).
+
+The `check_arg` helper (35 bytes) validates and prints
+`"<cmd>: missing argument"` on failure. Returns C=1 so caller can
+`BCS` to prompt. Used by 5 commands — saves ~25 bytes per caller
+vs inline checks.
+
+### Optional arg (ls)
+
+Check if arg is empty. If so, send bare command ("LS"). If not,
+use `build_cmd` to construct "LS,<arg>".
+
+### Two args (mv, cp)
+
+The `split_args` helper (40 bytes) walks ZP_ARG forward looking for
+a space. Null-terminates first arg in place, advances past spaces,
+points ZP_ARG2 at second arg. Returns C=1 if either arg is missing.
+Modifies LINE_BUF in place — safe because the buffer is disposable
+after dispatch.
+
+Similarly, `build_two_arg_cmd` (35 bytes) constructs `"XX,<src>,<dst>"`
+in DISK_BUF from ZP_ARG and ZP_ARG2. Used by `mv`; `cp` builds its
+OPEN commands inline since the prefix is `"OP,R,"` / `"OP,W,"` (not
+a 2-char opcode).
+
+## ZP Conventions
+
+| Range | Purpose |
+|-------|---------|
+| $E0-$E1 | ZP_PTR — general pointer (print_str, etc.) |
+| $E2-$E3 | ZP_PTR2 — second pointer (str_equal) |
+| $E4-$E5 | ZP_CMD — command word pointer (set by parser) |
+| $E6-$E7 | ZP_ARG — argument pointer (set by parser) |
+| $E8 | ZP_LEN — line buffer length |
+| $E9 | ZP_POS — cursor position |
+| $EA | ZP_TMP — temp byte |
+| $EB | ZP_CHAN — current disk channel ID |
+| $EC-$ED | ZP_ARG2 — second arg pointer (mv) |
+| $EE | ZP_DCNT — disk byte counter |
+| $EF | ZP_DFLG — disk flags |
+| $F0 | ZP_CHAN2 — second disk channel (cp) |
+
+Rule: use the `$E0-$FF` range for shell state. The `$00-$DF` range
+belongs to cc65 runtime and user programs.
+
+## ROM Budget
+
+All 9 commands fit in 1894 bytes (46% of 4KB shell ROM).
+
+| Phase | Binary | Delta | What was added |
+|-------|--------|-------|----------------|
+| Baseline | 597 | — | Shell with stub ls/cd |
+| pwd | 713 | +116 | pwd, disk_stream_to_con |
+| cd | 1120 | +407 | cd, build_cmd, disk_send_cmd, disk_check_error, error table |
+| ls | 1246 | +126 | ls parser, disk_read_to_buf |
+| cat | 1351 | +105 | cat, disk_close_chan |
+| mkdir,rmdir,rm,mv | 1625 | +274 | 4 handlers, check_arg, split_args |
+| cp | 1894 | +269 | cp, split_args refactor, build_two_arg_cmd, ZP_CHAN2 |
+
+Shared subroutines amortize well. The biggest one-time cost is the
+error string table (~260 bytes). After that, each new simple command
+adds only ~12-15 bytes at the call site.
+
+## Multi-Channel Operations (cp)
+
+`cp` holds two file channels open simultaneously:
+- ZP_CHAN = source (read)
+- ZP_CHAN2 = destination (write)
+
+The copy loop switches DISK_CHAN between src and dst on every byte.
+This works because DISK_CHAN is just a register select — switching
+channels doesn't disturb either channel's state.
+
+Close order matters: close dst first (flush writes), then close src.
+On error opening dst, still close src before returning.
+
+```asm
+@cbyte:
+    LDA ZP_CHAN             ; select src
+    STA N8_DISK_CHAN
+    LDA N8_DISK_DATA        ; read byte
+    PHA
+    LDA ZP_CHAN2            ; select dst
+    STA N8_DISK_CHAN
+    PLA
+    STA N8_DISK_DATA         ; write byte
+    LDA ZP_CHAN             ; back to src for status poll
+    STA N8_DISK_CHAN
+```
+
+6 register writes per byte copied. Could be optimized with a
+buffered approach (read N bytes into RAM, switch to dst, write N
+bytes), but the simple version is clear and correct.
+
+## 6502 Gotchas Encountered
+
+### Branch range limits
+
+Conditional branches (BCS, BCC, BEQ, BNE) have a signed 8-bit
+offset: -128 to +127 bytes. The `cp` handler is large enough that
+forward branches to error handlers at the bottom exceed this range.
+
+Fix: invert the condition and use JMP:
+```asm
+    ; Instead of: BCS @far_label
+    BCC @nearby_ok
+    JMP @far_label
+@nearby_ok:
+```
+
+Costs 2 extra bytes per occurrence. Watch for this whenever a
+handler exceeds ~100 bytes of code.
+
+### INX overflow as bounds check
+
+`INX / BEQ @done` gives a free 256-byte buffer overflow guard:
+when X wraps from $FF to $00, the zero flag fires. Used in
+`disk_read_to_buf`. Only works for exactly 256-byte buffers.

--- a/firmware/n8_memory_map.inc
+++ b/firmware/n8_memory_map.inc
@@ -104,6 +104,20 @@
 .define N8_KEY_F1          $80
 .define N8_KEY_F12         $8B
 
+; --- Storage (slot 4) ---
+.define N8_DISK_CHAN          $D880
+.define N8_DISK_DATA          $D881
+.define N8_DISK_ERROR         $D882
+.define N8_DISK_CTRL          $D883
+.define N8_DISK_STATUS        $D884
+
+.define N8_DISK_CONTROL_CHAN  $0F
+.define N8_DISK_CHAN_ACTIVE   $20
+.define N8_DISK_ERR_CMD       $80
+.define N8_DISK_STAT_AVAIL    $0F
+.define N8_DISK_STAT_EOF      $20
+.define N8_DISK_STAT_BUSY     $80
+
 ; --- Frame Buffer ---
 .define N8_FB_BASE        $C000
 .define N8_FB_SIZE        $1000

--- a/firmware/shell.s
+++ b/firmware/shell.s
@@ -25,10 +25,16 @@ ZP_ARG   = $E6
 ZP_LEN   = $E8
 ZP_POS   = $E9
 ZP_TMP   = $EA
+ZP_CHAN  = $EB
+ZP_ARG2 = $EC              ; second arg pointer (mv), 2 bytes
+ZP_DCNT = $EE              ; disk byte counter
+ZP_DFLG = $EF              ; disk flags
+ZP_CHAN2 = $F0             ; second disk channel (cp)
 
 ; --- Line buffer in unallocated RAM ---
-LINE_BUF = $0200
-LINE_MAX = 79
+LINE_BUF  = $0200
+LINE_MAX  = 79
+DISK_BUF  = $0300          ; 256-byte disk I/O buffer
 
 .segment "RODATA"
 
@@ -40,13 +46,51 @@ err_prefix: .byte "unknown command: ",0
 cmd_table:
         .word cmd_ls_name, cmd_ls
         .word cmd_cd_name, cmd_cd
+        .word cmd_pwd_name, cmd_pwd
+        .word cmd_cat_name, cmd_cat
+        .word cmd_mkdir_name, cmd_mkdir
+        .word cmd_rmdir_name, cmd_rmdir
+        .word cmd_rm_name, cmd_rm
+        .word cmd_mv_name, cmd_mv
+        .word cmd_cp_name, cmd_cp
         .word $0000
 
-cmd_ls_name: .byte "ls",0
-cmd_cd_name: .byte "cd",0
+cmd_ls_name:    .byte "ls",0
+cmd_cd_name:    .byte "cd",0
+cmd_pwd_name:   .byte "pwd",0
+cmd_cat_name:   .byte "cat",0
+cmd_mkdir_name: .byte "mkdir",0
+cmd_rmdir_name: .byte "rmdir",0
+cmd_rm_name:    .byte "rm",0
+cmd_mv_name:    .byte "mv",0
+cmd_cp_name:    .byte "cp",0
 
-msg_ls:  .byte "ls: no filesystem",0
-msg_cd:  .byte "cd: no filesystem",0
+str_ls_bare:     .byte "LS",0
+msg_pwd_err:     .byte "pwd: error",0
+msg_missing_arg: .byte "missing argument",0
+msg_mv_usage:    .byte "mv: usage: mv <src> <dst>",0
+msg_cp_usage:    .byte "cp: usage: cp <src> <dst>",0
+msg_generic_err: .byte "error",0
+
+; Command error string table ($01-$0E)
+err_tbl:
+        .word err_01, err_02, err_03, err_04, err_05, err_06, err_07
+        .word err_08, err_09, err_0a, err_0b, err_0c, err_0d, err_0e
+
+err_01: .byte "not found",0
+err_02: .byte "already exists",0
+err_03: .byte "dir not found",0
+err_04: .byte "not open",0
+err_05: .byte "no free channel",0
+err_06: .byte "disk full",0
+err_07: .byte "is a directory",0
+err_08: .byte "permission denied",0
+err_09: .byte "bad syntax",0
+err_0a: .byte "bad argument",0
+err_0b: .byte "name too long",0
+err_0c: .byte "not a directory",0
+err_0d: .byte "not empty",0
+err_0e: .byte "not ready",0
 
 .segment "CODE"
 
@@ -386,19 +430,753 @@ process_line:
 ; =================================================================
 ; Command handlers (stubs)
 ; =================================================================
+; =================================================================
+; cmd_ls -- List directory (buffer + parse approach)
+;
+; Pattern: disk_read_to_buf reads entire response into DISK_BUF,
+;   then a state machine walks the buffer to reformat entries.
+;   Needed when raw device format differs from display format.
+;
+; Raw LS format per entry: D|F \t <name> \t <size_lo> <size_hi> \n
+; Compact display: <name>/ (for dirs) or <name> (for files), one per line
+; =================================================================
 cmd_ls:
-        LDA #<msg_ls
-        LDX #>msg_ls
+        ; Build "LS" or "LS,<arg>" depending on whether arg exists
+        LDY #0
+        LDA (ZP_ARG),Y
+        BEQ @ls_noarg
+
+        ; Has arg: build "LS,<arg>"
+        LDA #'L'
+        LDX #'S'
+        JSR build_cmd
+        JMP @ls_send
+
+@ls_noarg:
+        ; No arg: just send "LS"
+        LDA #<str_ls_bare
+        STA ZP_PTR
+        LDA #>str_ls_bare
+        STA ZP_PTR+1
+
+@ls_send:
+        JSR disk_send_cmd
+        JSR disk_check_error
+        BCS @ls_ret
+
+        ; Read channel ID
+        LDA N8_DISK_DATA
+        STA ZP_CHAN
+        STA N8_DISK_CHAN
+
+        ; Read response into buffer
+        JSR disk_read_to_buf
+
+        ; Parse buffer: walk entries
+        ; Format: type(1) \t name... \t size_lo size_hi \n
+        LDX #0                  ; buffer index
+@entry:
+        CPX ZP_DCNT
+        BCS @ls_done            ; past end of data
+
+        ; Read type byte (D or F)
+        LDA DISK_BUF,X
+        CMP #'D'
+        BEQ @is_dir
+        LDA #0
+        STA ZP_DFLG             ; not a directory
+        JMP @skip_tab1
+@is_dir:
+        LDA #1
+        STA ZP_DFLG             ; is a directory
+
+@skip_tab1:
+        INX                     ; skip type byte
+        CPX ZP_DCNT
+        BCS @ls_done
+        INX                     ; skip \t
+        CPX ZP_DCNT
+        BCS @ls_done
+
+        ; Print name bytes until \t
+@name:
+        CPX ZP_DCNT
+        BCS @ls_done
+        LDA DISK_BUF,X
+        CMP #$09                ; tab = end of name
+        BEQ @name_done
+        JSR K_CON_PUTCHAR
+        INX
+        JMP @name
+
+@name_done:
+        ; If directory, print '/'
+        LDA ZP_DFLG
+        BEQ @skip_slash
+        LDA #'/'
+        JSR K_CON_PUTCHAR
+@skip_slash:
+
+        ; Skip \t + size_lo + size_hi + \n (4 bytes)
+        INX                     ; \t
+        INX                     ; size_lo
+        INX                     ; size_hi
+        INX                     ; \n
+
+        JSR K_CON_NEWLINE
+        JMP @entry
+
+@ls_done:
+@ls_ret:
+        JMP prompt_loop
+
+; =================================================================
+; cmd_cd -- Change directory (buffer-based command construction)
+;
+; Pattern: build_cmd constructs "XX,<arg>" in DISK_BUF, then
+;   disk_send_cmd sends it. More flexible than inline sends —
+;   handles variable-length arguments naturally.
+; Pattern: disk_check_error reads DISK_ERROR, looks up error
+;   string from table, prints "<cmd>: <message>". Returns C=1
+;   on error so caller can BCS to prompt_loop.
+; =================================================================
+cmd_cd:
+        JSR check_arg
+        BCS @cd_ret
+        LDA #'C'
+        LDX #'D'
+        JSR build_cmd
+        JSR disk_send_cmd
+        JSR disk_check_error
+@cd_ret:
+        JMP prompt_loop
+
+; =================================================================
+; cmd_mkdir -- Create directory
+; =================================================================
+cmd_mkdir:
+        JSR check_arg
+        BCS @mk_ret
+        LDA #'M'
+        LDX #'D'
+        JSR build_cmd
+        JSR disk_send_cmd
+        JSR disk_check_error
+@mk_ret:
+        JMP prompt_loop
+
+; =================================================================
+; cmd_rmdir -- Remove empty directory
+; =================================================================
+cmd_rmdir:
+        JSR check_arg
+        BCS @rd_ret
+        LDA #'R'
+        LDX #'D'
+        JSR build_cmd
+        JSR disk_send_cmd
+        JSR disk_check_error
+@rd_ret:
+        JMP prompt_loop
+
+; =================================================================
+; cmd_rm -- Remove file
+; =================================================================
+cmd_rm:
+        JSR check_arg
+        BCS @rm_ret
+        LDA #'R'
+        LDX #'M'
+        JSR build_cmd
+        JSR disk_send_cmd
+        JSR disk_check_error
+@rm_ret:
+        JMP prompt_loop
+
+; =================================================================
+; cmd_mv -- Move/rename (uses split_args + build_two_arg_cmd)
+; =================================================================
+cmd_mv:
+        JSR split_args
+        BCS @mv_usage
+        LDA #'M'
+        LDX #'V'
+        JSR build_two_arg_cmd
+        JSR disk_send_cmd
+        JSR disk_check_error
+        JMP prompt_loop
+@mv_usage:
+        LDA #<msg_mv_usage
+        LDX #>msg_mv_usage
         JSR print_str
         JSR K_CON_NEWLINE
         JMP prompt_loop
 
-cmd_cd:
-        LDA #<msg_cd
-        LDX #>msg_cd
+; =================================================================
+; cmd_cp -- Copy file (open src read, open dst write, copy, close)
+;
+; Pattern: two file channels open simultaneously. ZP_CHAN = src
+;   (read), ZP_CHAN2 = dst (write). Stream bytes from src data
+;   channel to dst data channel. Close both when done.
+; =================================================================
+cmd_cp:
+        JSR split_args
+        BCC @cp_args_ok
+        JMP @cp_usage
+@cp_args_ok:
+
+        ; Open src for read: "OP,R,<src>"
+        LDX #0
+        LDA #'O'
+        STA DISK_BUF,X
+        INX
+        LDA #'P'
+        STA DISK_BUF,X
+        INX
+        LDA #','
+        STA DISK_BUF,X
+        INX
+        LDA #'R'
+        STA DISK_BUF,X
+        INX
+        LDA #','
+        STA DISK_BUF,X
+        INX
+        LDY #0
+@cps:   LDA (ZP_ARG),Y
+        STA DISK_BUF,X
+        BEQ @src_built
+        INX
+        INY
+        BNE @cps
+@src_built:
+        LDA #<DISK_BUF
+        STA ZP_PTR
+        LDA #>DISK_BUF
+        STA ZP_PTR+1
+        JSR disk_send_cmd
+        JSR disk_check_error
+        BCC @cp_src_ok
+        JMP @cp_ret
+@cp_src_ok:
+        ; Save src channel
+        LDA N8_DISK_DATA
+        STA ZP_CHAN
+
+        ; Open dst for write: "OP,W,<dst>"
+        LDX #0
+        LDA #'O'
+        STA DISK_BUF,X
+        INX
+        LDA #'P'
+        STA DISK_BUF,X
+        INX
+        LDA #','
+        STA DISK_BUF,X
+        INX
+        LDA #'W'
+        STA DISK_BUF,X
+        INX
+        LDA #','
+        STA DISK_BUF,X
+        INX
+        LDY #0
+@cpd:   LDA (ZP_ARG2),Y
+        STA DISK_BUF,X
+        BEQ @dst_built
+        INX
+        INY
+        BNE @cpd
+@dst_built:
+        LDA #<DISK_BUF
+        STA ZP_PTR
+        LDA #>DISK_BUF
+        STA ZP_PTR+1
+        JSR disk_send_cmd
+        JSR disk_check_error
+        BCS @cp_close_src       ; close src if dst open failed
+
+        ; Save dst channel
+        LDA N8_DISK_DATA
+        STA ZP_CHAN2
+
+        ; Copy loop: read from src, write to dst
+        LDA ZP_CHAN
+        STA N8_DISK_CHAN         ; select src channel
+@cpoll:
+        LDA N8_DISK_STATUS
+        TAX
+        AND #N8_DISK_STAT_AVAIL
+        BNE @cread
+        TXA
+        AND #N8_DISK_STAT_EOF
+        BNE @cp_done
+        JMP @cpoll
+@cread:
+        TAY                     ; Y = avail count
+@cbyte:
+        ; Read from src
+        LDA ZP_CHAN
+        STA N8_DISK_CHAN
+        LDA N8_DISK_DATA
+        PHA
+        ; Write to dst
+        LDA ZP_CHAN2
+        STA N8_DISK_CHAN
+        PLA
+        STA N8_DISK_DATA
+        ; Switch back to src for next read
+        LDA ZP_CHAN
+        STA N8_DISK_CHAN
+        DEY
+        BNE @cbyte
+        JMP @cpoll
+
+@cp_done:
+        ; Close dst channel
+        LDA ZP_CHAN
+        PHA                     ; save src channel ID
+        LDA ZP_CHAN2
+        STA ZP_CHAN
+        JSR disk_close_chan
+        PLA
+        STA ZP_CHAN             ; restore src channel ID
+@cp_close_src:
+        ; Close src channel
+        JSR disk_close_chan
+        JMP prompt_loop
+
+@cp_usage:
+        LDA #<msg_cp_usage
+        LDX #>msg_cp_usage
+        JSR print_str
+        JSR K_CON_NEWLINE
+@cp_ret:
+        JMP prompt_loop
+
+; =================================================================
+; cmd_cat -- Display file contents (open, stream, close)
+;
+; Pattern: file channel lifecycle — OPEN returns a channel ID,
+;   stream data to console, then CLOSE via binary CL command.
+;   Unlike response channels (pwd, ls), file channels do NOT
+;   auto-close at EOF — explicit close is required.
+; =================================================================
+cmd_cat:
+        JSR check_arg
+        BCS @cat_ret
+        ; Build "OP,R,<filename>" in DISK_BUF
+        ; Can't use build_cmd (2-char opcode), so build inline
+        LDX #0
+        LDA #'O'
+        STA DISK_BUF,X
+        INX
+        LDA #'P'
+        STA DISK_BUF,X
+        INX
+        LDA #','
+        STA DISK_BUF,X
+        INX
+        LDA #'R'
+        STA DISK_BUF,X
+        INX
+        LDA #','
+        STA DISK_BUF,X
+        INX
+        ; Copy filename from ZP_ARG
+        LDY #0
+@cpy:   LDA (ZP_ARG),Y
+        STA DISK_BUF,X
+        BEQ @cpy_done
+        INX
+        INY
+        BNE @cpy
+@cpy_done:
+        LDA #<DISK_BUF
+        STA ZP_PTR
+        LDA #>DISK_BUF
+        STA ZP_PTR+1
+
+        JSR disk_send_cmd
+        JSR disk_check_error
+        BCS @cat_ret
+
+        ; Read channel ID, select data channel
+        LDA N8_DISK_DATA
+        STA ZP_CHAN
+        STA N8_DISK_CHAN
+
+        ; Stream file contents to console
+        JSR disk_stream_to_con
+
+        ; Close file channel (required — not auto-close)
+        JSR disk_close_chan
+
+@cat_ret:
+        JMP prompt_loop
+
+; =================================================================
+; cmd_pwd -- Print working directory (inline send, stream response)
+;
+; Pattern: inline sends — write command bytes directly to DISK_DATA.
+;   Tightest code for fixed (no-argument) commands.
+; Pattern: stream-to-console — read DISK_DATA → K_CON_PUTCHAR in
+;   a poll loop driven by DISK_STATUS. Best for commands where
+;   response goes straight to screen with no reformatting.
+; =================================================================
+cmd_pwd:
+        ; Select control channel (clears any prior error)
+        LDA #N8_DISK_CONTROL_CHAN
+        STA N8_DISK_CHAN
+
+        ; Send "PD" + null terminator inline
+        LDA #'P'
+        STA N8_DISK_DATA
+        LDA #'D'
+        STA N8_DISK_DATA
+        LDA #$00
+        STA N8_DISK_DATA        ; null = execute command
+
+        ; Check for error
+        LDA N8_DISK_ERROR
+        AND #N8_DISK_ERR_CMD
+        BNE @pwd_err
+
+        ; Read channel ID from response
+        LDA N8_DISK_DATA
+        STA ZP_CHAN
+        STA N8_DISK_CHAN         ; select response channel
+
+        ; Stream response to console
+        JSR disk_stream_to_con
+        JSR K_CON_NEWLINE
+        JMP prompt_loop
+
+@pwd_err:
+        ; For now, generic error (Phase 2 adds proper error table)
+        LDA #<msg_pwd_err
+        LDX #>msg_pwd_err
         JSR print_str
         JSR K_CON_NEWLINE
         JMP prompt_loop
+
+; =================================================================
+; disk_stream_to_con -- Stream data channel to console
+;
+;   Prereq: data channel already selected via DISK_CHAN
+;   Reads DISK_DATA bytes, sends each to K_CON_PUTCHAR.
+;   Converts $0A (LF) to K_CON_NEWLINE.
+;   Polls DISK_STATUS for avail/EOF/busy.
+;   Returns when EOF reached and buffer drained.
+;   Clobbers: A, X, Y
+; =================================================================
+disk_stream_to_con:
+@poll:
+        LDA N8_DISK_STATUS
+        TAX                     ; save full status
+        AND #N8_DISK_STAT_AVAIL
+        BNE @read               ; bytes available
+        TXA
+        AND #N8_DISK_STAT_EOF
+        BNE @done               ; EOF, no more data
+        JMP @poll               ; busy — wait
+
+@read:
+        TAY                     ; Y = bytes available count
+@byte:
+        LDA N8_DISK_DATA
+        CMP #$0A
+        BEQ @newline
+        JSR K_CON_PUTCHAR
+        JMP @next
+@newline:
+        JSR K_CON_NEWLINE
+@next:
+        DEY
+        BNE @byte
+        JMP @poll               ; check for more
+
+@done:
+        RTS
+
+; =================================================================
+; check_arg -- Verify ZP_ARG is not empty
+;   Out: C=0 if arg present, C=1 if missing (prints message)
+;   Prints "<cmd>: missing argument" on missing.
+;   Clobbers: A, Y, ZP_PTR
+; =================================================================
+check_arg:
+        LDY #0
+        LDA (ZP_ARG),Y
+        BNE @has_arg
+        ; Print "<cmd>: missing argument"
+        LDA ZP_CMD
+        STA ZP_PTR
+        LDA ZP_CMD+1
+        STA ZP_PTR+1
+        LDY #0
+@pn:    LDA (ZP_PTR),Y
+        BEQ @sep
+        JSR K_CON_PUTCHAR
+        INY
+        BNE @pn
+@sep:   LDA #':'
+        JSR K_CON_PUTCHAR
+        LDA #' '
+        JSR K_CON_PUTCHAR
+        LDA #<msg_missing_arg
+        LDX #>msg_missing_arg
+        JSR print_str
+        JSR K_CON_NEWLINE
+        SEC
+        RTS
+@has_arg:
+        CLC
+        RTS
+
+; =================================================================
+; split_args -- Split ZP_ARG into two args at first space
+;   Out: C=0 if both args present (ZP_ARG=first, ZP_ARG2=second)
+;        C=1 if missing (prints nothing — caller handles message)
+;   Modifies LINE_BUF in place (null-terminates first arg).
+;   Clobbers: A, Y
+; =================================================================
+split_args:
+        LDY #0
+        LDA (ZP_ARG),Y
+        BEQ @fail               ; empty = no first arg
+        ; Find space
+@find:  LDA (ZP_ARG),Y
+        BEQ @fail               ; null before space = no second arg
+        CMP #' '
+        BEQ @split
+        INY
+        BNE @find
+@split:
+        LDA #0
+        STA (ZP_ARG),Y          ; null-terminate first arg
+        INY
+@skip:  LDA (ZP_ARG),Y
+        CMP #' '
+        BNE @got
+        INY
+        BNE @skip
+@got:   LDA (ZP_ARG),Y
+        BEQ @fail               ; empty second arg
+        TYA
+        CLC
+        ADC ZP_ARG
+        STA ZP_ARG2
+        LDA ZP_ARG+1
+        ADC #0
+        STA ZP_ARG2+1
+        CLC
+        RTS
+@fail:  SEC
+        RTS
+
+; =================================================================
+; build_cmd -- Build "XX,<arg>" in DISK_BUF
+;   In: A = first command char, X = second command char
+;       ZP_ARG = pointer to null-terminated argument
+;   Out: ZP_PTR = DISK_BUF (ready for disk_send_cmd)
+;   Clobbers: Y, A
+; =================================================================
+build_cmd:
+        STA DISK_BUF+0
+        STX DISK_BUF+1
+        LDA #','
+        STA DISK_BUF+2
+        ; Copy arg bytes
+        LDY #0
+@copy:  LDA (ZP_ARG),Y
+        STA DISK_BUF+3,Y
+        BEQ @done               ; copied the null terminator
+        INY
+        BNE @copy
+@done:
+        LDA #<DISK_BUF
+        STA ZP_PTR
+        LDA #>DISK_BUF
+        STA ZP_PTR+1
+        RTS
+
+; =================================================================
+; build_two_arg_cmd -- Build "XX,<arg1>,<arg2>" in DISK_BUF
+;   In: A = first cmd char, X = second cmd char
+;       ZP_ARG = first arg, ZP_ARG2 = second arg
+;   Out: ZP_PTR = DISK_BUF
+;   Clobbers: X, Y, A
+; =================================================================
+build_two_arg_cmd:
+        STA DISK_BUF+0
+        STX DISK_BUF+1
+        LDA #','
+        STA DISK_BUF+2
+        LDX #3
+        ; Copy first arg
+        LDY #0
+@cp1:   LDA (ZP_ARG),Y
+        BEQ @sep
+        STA DISK_BUF,X
+        INX
+        INY
+        BNE @cp1
+@sep:   LDA #','
+        STA DISK_BUF,X
+        INX
+        ; Copy second arg
+        LDY #0
+@cp2:   LDA (ZP_ARG2),Y
+        STA DISK_BUF,X
+        BEQ @done
+        INX
+        INY
+        BNE @cp2
+@done:
+        LDA #<DISK_BUF
+        STA ZP_PTR
+        LDA #>DISK_BUF
+        STA ZP_PTR+1
+        RTS
+
+; =================================================================
+; disk_send_cmd -- Send command at (ZP_PTR) to control channel
+;   Selects control channel first (clears prior error).
+;   Sends bytes including null terminator (which executes cmd).
+;   Clobbers: A, Y
+; =================================================================
+disk_send_cmd:
+        LDA #N8_DISK_CONTROL_CHAN
+        STA N8_DISK_CHAN
+        LDY #0
+@loop:  LDA (ZP_PTR),Y
+        STA N8_DISK_DATA
+        BEQ @done
+        INY
+        BNE @loop
+@done:  RTS
+
+; =================================================================
+; disk_check_error -- Check DISK_ERROR after command execution
+;   If bit 7 set: prints "<cmd>: <message>" and sets C=1
+;   If no error: clears C
+;   Prereq: ZP_CMD points to command name (set by process_line)
+;   Clobbers: A, X, Y, ZP_PTR
+; =================================================================
+disk_check_error:
+        LDA N8_DISK_ERROR
+        AND #N8_DISK_ERR_CMD
+        BEQ @no_err
+
+        ; Read the command error code
+        LDA N8_DISK_DATA
+        TAX                     ; X = error code
+
+        ; Print command name
+        LDA ZP_CMD
+        STA ZP_PTR
+        LDA ZP_CMD+1
+        STA ZP_PTR+1
+        LDY #0
+@pname: LDA (ZP_PTR),Y
+        BEQ @sep
+        JSR K_CON_PUTCHAR
+        INY
+        BNE @pname
+
+@sep:   ; Print ": "
+        LDA #':'
+        JSR K_CON_PUTCHAR
+        LDA #' '
+        JSR K_CON_PUTCHAR
+
+        ; Look up error message (code $01-$0E → table index 0-13)
+        DEX                     ; code-1 = index
+        CPX #14
+        BCS @generic            ; out of range
+        TXA
+        ASL A                   ; *2 for word offset
+        TAX
+        LDA err_tbl,X
+        STA ZP_PTR
+        LDA err_tbl+1,X
+        STA ZP_PTR+1
+        LDY #0
+@pmsg:  LDA (ZP_PTR),Y
+        BEQ @eol
+        JSR K_CON_PUTCHAR
+        INY
+        BNE @pmsg
+@eol:
+        JSR K_CON_NEWLINE
+        SEC
+        RTS
+
+@generic:
+        LDA #<msg_generic_err
+        LDX #>msg_generic_err
+        JSR print_str
+        JSR K_CON_NEWLINE
+        SEC
+        RTS
+
+@no_err:
+        CLC
+        RTS
+
+; =================================================================
+; disk_close_chan -- Close channel in ZP_CHAN via binary CL command
+;   Sends CL,<chan_id> with binary payload.
+;   Clobbers: A
+; =================================================================
+disk_close_chan:
+        LDA #N8_DISK_CONTROL_CHAN
+        STA N8_DISK_CHAN
+        LDA #'C'
+        STA N8_DISK_DATA
+        LDA #'L'
+        STA N8_DISK_DATA
+        LDA #','
+        STA N8_DISK_DATA
+        LDA ZP_CHAN
+        STA N8_DISK_DATA
+        LDA #$00
+        STA N8_DISK_DATA
+        RTS
+
+; =================================================================
+; disk_read_to_buf -- Read data channel into DISK_BUF
+;   Prereq: data channel already selected via DISK_CHAN
+;   Out: ZP_DCNT = total bytes read (max 256, stored as 0 if 256)
+;   Clobbers: A, X, Y
+; =================================================================
+disk_read_to_buf:
+        LDX #0                  ; buffer index
+@poll:
+        LDA N8_DISK_STATUS
+        TAY                     ; save full status
+        AND #N8_DISK_STAT_AVAIL
+        BNE @read
+        TYA
+        AND #N8_DISK_STAT_EOF
+        BNE @done
+        JMP @poll               ; busy — wait
+
+@read:
+        TAY                     ; Y = avail count
+@byte:
+        LDA N8_DISK_DATA
+        STA DISK_BUF,X
+        INX
+        BEQ @done               ; wrapped to 0 = buffer full (256)
+        DEY
+        BNE @byte
+        JMP @poll
+
+@done:
+        STX ZP_DCNT
+        RTS
 
 ; =================================================================
 ; print_str -- Print null-terminated string


### PR DESCRIPTION
## Summary
- Wire the shell to storage device registers with 9 working commands: `ls`, `cd`, `pwd`, `cat`, `mkdir`, `rmdir`, `rm`, `mv`, `cp`
- Add storage register defines to `firmware/n8_memory_map.inc`
- Implement shared subroutines (send_cmd, check_error, stream_to_con, read_to_buf, close_chan, build_cmd, check_arg, split_args) that amortize well across commands
- Error table maps all 14 command error codes to human-readable strings
- Document firmware best practices in `firmware/STORAGE_PATTERNS.md` covering command construction patterns, I/O strategies, channel lifecycle, and 6502 gotchas
- Binary size: 1894 bytes (46% of 4KB shell ROM)

## Test plan
- [x] `pwd` → prints `/`
- [x] `ls` → lists `dir/` and `test.txt` with dir suffix
- [x] `ls dir` → lists empty dir
- [x] `ls noexist` → `ls: not found`
- [x] `cd dir` → `pwd` shows `/dir`
- [x] `cd noexist` → `cd: dir not found`
- [x] `cd` (no arg) → `cd: missing argument`
- [x] `cat test.txt` → displays file contents
- [x] `cat nofile` → `cat: not found`
- [x] `mkdir testdir` → visible in `ls`
- [x] `rmdir testdir` → removed from `ls`
- [x] `mv test.txt renamed.txt` → `ls` reflects rename
- [x] `rm renamed.txt` → removed from `ls`
- [x] `mv` (no args) → usage message
- [x] `cp test.txt copy.txt` → `cat copy.txt` matches original
- [x] `cp nofile dst` → `cp: not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)